### PR TITLE
feat(types): add capacityWh and features to PostMetadata

### DIFF
--- a/components/PostMetadata.ts
+++ b/components/PostMetadata.ts
@@ -15,6 +15,8 @@ export interface PostMetadata {
     rating?: number;
     retailerLinks?: Record<string, string>;
     category?: string;
+    capacityWh?: number;
+    features?: string[];
     ratingBreakdown?: {
       overallScore?: number;
       overallRank?: string;


### PR DESCRIPTION
## Summary
Extends the `PostMetadata` interface with two new optional fields needed by the power station data layer: `capacityWh` (battery capacity in Wh as a number) and `features` (array of tag strings for category filtering).

## Details
- Added `capacityWh?: number` to `components/PostMetadata.ts` for numeric capacity filtering
- Added `features?: string[]` for tag-based filtering (e.g. `"30a-rv"`, `"solar"`, `"240v"`, `"cpap"`, `"van-life"`)
- No behaviour change — both fields are optional and backward compatible

## Testing Done
- [ ] `npm run type-check` passes clean
- [ ] No existing pages affected (fields are optional)