### PR TITLE
feat(pages): add 7 use-case power station category pages

### DIFF
--- a/app/best/power-stations/240v-power-stations/page.tsx
+++ b/app/best/power-stations/240v-power-stations/page.tsx
@@ -1,0 +1,145 @@
+import { Metadata } from 'next';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { QuickPicks } from '@/components/QuickPicks';
+import { RankedProductCard } from '@/components/RankedProductCard';
+import { Newsletter } from '@/components/Newsletter';
+import AdBanner from '@/components/ads/AdBanner';
+import { ADSENSE_CONFIG } from '@/lib/adsense-config';
+import { getStationsByFeature, getQuickPicks } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'Best 240V Portable Power Stations 2025',
+  description: 'Power stations with 240V split-phase output for dryers, AC units, and EV charging. Expert tested.',
+};
+
+export default function TwoFortyVPowerStationsPage() {
+  const stations = getStationsByFeature('240v');
+  const quickPicks = getQuickPicks(stations);
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: '240V Power Stations' },
+      ]} />
+
+      <div className="bg-gradient-to-br from-primary to-primary-dark px-6 py-10 text-white">
+        <div className="mx-auto max-w-content">
+          <SectionLabel className="text-white/70">Buying Guide</SectionLabel>
+          <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">Best 240V Portable Power Stations 2025</h1>
+          <p className="mt-2 max-w-2xl text-base text-white/80">
+            Power stations with 240V split-phase output for dryers, AC units, and EV charging — expert tested for heavy-duty home backup.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {['240V Output', 'Split-Phase', 'Home Backup'].map((tag) => (
+              <span key={tag} className="rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs text-white/90">{tag}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <QuickPicks picks={quickPicks} />
+
+            <div>
+              <SectionLabel>Ranked List</SectionLabel>
+              <div className="space-y-4">
+                {stations.map((station, i) => (
+                  <div key={station.slug}>
+                    <RankedProductCard
+                      rank={i + 1}
+                      name={station.title}
+                      href={`/articles/${station.slug}`}
+                      image={station.image}
+                      summary={station.subtitle}
+                      score={station.score}
+                      price={station.price}
+                      specs={station.specs}
+                    />
+                    {i === 2 && (
+                      <div className="mt-4">
+                        <AdBanner adSlot={ADSENSE_CONFIG.adSlots.categoryBottom} adFormat="auto" className="rounded-lg" />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-6">
+              <SectionLabel>Buying Guide</SectionLabel>
+              <h2 className="mb-4 text-lg font-bold text-neutral-900">Understanding 240V Power Stations</h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    title: 'What Requires 240V?',
+                    items: [
+                      'Electric dryers (5,000–6,000W)',
+                      'Central air conditioning (3,500–5,000W)',
+                      'Level 2 EV chargers (7,200W)',
+                      'Many well pumps (750–2,000W)',
+                      '240V ranges and ovens (3,000–12,000W)',
+                    ],
+                  },
+                  {
+                    title: 'Split-Phase Explained',
+                    items: [
+                      'US 240V uses two 120V legs 180° out of phase',
+                      'A single inverter outputting 240V must generate both legs',
+                      'Most portable stations do 120V only — 240V is a premium feature',
+                      'Verify the outlet type: NEMA 14-50 (50A) vs L14-30 (30A)',
+                    ],
+                  },
+                ].map((section) => (
+                  <div key={section.title}>
+                    <h3 className="mb-2 text-sm font-semibold text-primary">{section.title}</h3>
+                    <ul className="space-y-1">
+                      {section.items.map((item) => (
+                        <li key={item} className="text-xs text-neutral-600">• {item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </main>
+
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Jump To</h3>
+              <ul className="space-y-2 text-sm">
+                {stations.slice(0, 8).map((s, i) => (
+                  <li key={s.slug}>
+                    <a href={`#rank-${i + 1}`} className="text-neutral-600 hover:text-primary">
+                      #{i + 1} {s.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-primary">240V Appliance Wattage</h3>
+              <div className="space-y-1.5 text-xs text-neutral-600">
+                <p><strong>Electric dryer:</strong> 5,000–6,000W</p>
+                <p><strong>Central AC:</strong> 3,500–5,000W</p>
+                <p><strong>Level 2 EV charger:</strong> 7,200W</p>
+                <p><strong>Well pump:</strong> 750–2,000W</p>
+                <p className="mt-2">Always check your appliance&apos;s nameplate rating before selecting a power station.</p>
+              </div>
+            </div>
+
+            <AdBanner adSlot={ADSENSE_CONFIG.adSlots.sidebar} adFormat="rectangle" style={{ minHeight: 250 }} className="rounded-lg" />
+
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/best/power-stations/for-cpap/page.tsx
+++ b/app/best/power-stations/for-cpap/page.tsx
@@ -1,0 +1,146 @@
+import { Metadata } from 'next';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { QuickPicks } from '@/components/QuickPicks';
+import { RankedProductCard } from '@/components/RankedProductCard';
+import { Newsletter } from '@/components/Newsletter';
+import AdBanner from '@/components/ads/AdBanner';
+import { ADSENSE_CONFIG } from '@/lib/adsense-config';
+import { getStationsByFeature, getQuickPicks } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'Best Power Stations for CPAP Machines 2025',
+  description: 'Best power stations for CPAP machines — quiet, reliable, and with enough capacity for overnight use.',
+};
+
+export default function ForCpapPage() {
+  const stations = getStationsByFeature('cpap');
+  const quickPicks = getQuickPicks(stations);
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: 'For CPAP' },
+      ]} />
+
+      <div className="bg-gradient-to-br from-primary to-primary-dark px-6 py-10 text-white">
+        <div className="mx-auto max-w-content">
+          <SectionLabel className="text-white/70">Buying Guide</SectionLabel>
+          <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">Best Power Stations for CPAP Machines 2025</h1>
+          <p className="mt-2 max-w-2xl text-base text-white/80">
+            Quiet, reliable power stations with enough capacity for multiple nights of CPAP use — expert tested for sleep therapy dependability.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {['CPAP Compatible', '500–1500Wh', 'Quiet Operation'].map((tag) => (
+              <span key={tag} className="rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs text-white/90">{tag}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <QuickPicks picks={quickPicks} />
+
+            <div>
+              <SectionLabel>Ranked List</SectionLabel>
+              <div className="space-y-4">
+                {stations.map((station, i) => (
+                  <div key={station.slug}>
+                    <RankedProductCard
+                      rank={i + 1}
+                      name={station.title}
+                      href={`/articles/${station.slug}`}
+                      image={station.image}
+                      summary={station.subtitle}
+                      score={station.score}
+                      price={station.price}
+                      specs={station.specs}
+                    />
+                    {i === 2 && (
+                      <div className="mt-4">
+                        <AdBanner adSlot={ADSENSE_CONFIG.adSlots.categoryBottom} adFormat="auto" className="rounded-lg" />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-6">
+              <SectionLabel>Buying Guide</SectionLabel>
+              <h2 className="mb-4 text-lg font-bold text-neutral-900">Choosing a Power Station for Your CPAP</h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    title: 'How Many Nights Per Charge?',
+                    items: [
+                      'Average CPAP draws 30–60W (45W is a good estimate)',
+                      '1,000Wh ÷ 45W = ~22 hours = 2–3 nights of 8-hour sessions',
+                      'DC mode (12V) is 20–30% more efficient than AC mode',
+                      'Humidifier adds 15–30W — budget accordingly',
+                    ],
+                  },
+                  {
+                    title: 'DC Mode vs AC Mode for CPAP',
+                    items: [
+                      'DC mode bypasses the inverter for better efficiency',
+                      'Most CPAP machines accept 12V DC input via adapter',
+                      'AC mode is simpler but wastes 15–25% energy in conversion',
+                      'Units with dedicated DC ports are preferred for CPAP users',
+                    ],
+                  },
+                ].map((section) => (
+                  <div key={section.title}>
+                    <h3 className="mb-2 text-sm font-semibold text-primary">{section.title}</h3>
+                    <ul className="space-y-1">
+                      {section.items.map((item) => (
+                        <li key={item} className="text-xs text-neutral-600">• {item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </main>
+
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Jump To</h3>
+              <ul className="space-y-2 text-sm">
+                {stations.slice(0, 8).map((s, i) => (
+                  <li key={s.slug}>
+                    <a href={`#rank-${i + 1}`} className="text-neutral-600 hover:text-primary">
+                      #{i + 1} {s.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-primary">CPAP Runtime Table</h3>
+              <div className="space-y-2 text-xs text-neutral-600">
+                <p>CPAP machines draw <strong>30–60W on average</strong> (use 45W as your estimate).</p>
+                <div className="mt-2 space-y-1">
+                  <p><strong>500Wh</strong> → 8–16 nights (8-hr sessions, no humidifier)</p>
+                  <p><strong>1,000Wh</strong> → 16–33 nights</p>
+                  <p><strong>1,500Wh</strong> → 25–50 nights</p>
+                </div>
+                <p className="mt-2">Use DC mode when available to extend runtime by 20–30%.</p>
+              </div>
+            </div>
+
+            <AdBanner adSlot={ADSENSE_CONFIG.adSlots.sidebar} adFormat="rectangle" style={{ minHeight: 250 }} className="rounded-lg" />
+
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/best/power-stations/rv-power-stations/page.tsx
+++ b/app/best/power-stations/rv-power-stations/page.tsx
@@ -1,0 +1,142 @@
+import { Metadata } from 'next';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { QuickPicks } from '@/components/QuickPicks';
+import { RankedProductCard } from '@/components/RankedProductCard';
+import { Newsletter } from '@/components/Newsletter';
+import AdBanner from '@/components/ads/AdBanner';
+import { ADSENSE_CONFIG } from '@/lib/adsense-config';
+import { getStationsByFeature, getQuickPicks } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'Best Power Stations for RV 2025 — 30A & Solar Ready',
+  description: 'Top-rated power stations with 30A RV outlets and solar charging. Expert tested for RV and trailer use.',
+};
+
+export default function RvPowerStationsPage() {
+  const stations = getStationsByFeature('30a-rv');
+  const quickPicks = getQuickPicks(stations);
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: 'RV Power Stations' },
+      ]} />
+
+      <div className="bg-gradient-to-br from-primary to-primary-dark px-6 py-10 text-white">
+        <div className="mx-auto max-w-content">
+          <SectionLabel className="text-white/70">Buying Guide</SectionLabel>
+          <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">Best Power Stations for RV 2025</h1>
+          <p className="mt-2 max-w-2xl text-base text-white/80">
+            Power stations with genuine 30A RV outlets and solar charging — expert tested for full-time RV and trailer use.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {['30A RV Outlet', 'Solar Ready', 'High Capacity'].map((tag) => (
+              <span key={tag} className="rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs text-white/90">{tag}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <QuickPicks picks={quickPicks} />
+
+            <div>
+              <SectionLabel>Ranked List</SectionLabel>
+              <div className="space-y-4">
+                {stations.map((station, i) => (
+                  <div key={station.slug}>
+                    <RankedProductCard
+                      rank={i + 1}
+                      name={station.title}
+                      href={`/articles/${station.slug}`}
+                      image={station.image}
+                      summary={station.subtitle}
+                      score={station.score}
+                      price={station.price}
+                      specs={station.specs}
+                    />
+                    {i === 2 && (
+                      <div className="mt-4">
+                        <AdBanner adSlot={ADSENSE_CONFIG.adSlots.categoryBottom} adFormat="auto" className="rounded-lg" />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-6">
+              <SectionLabel>Buying Guide</SectionLabel>
+              <h2 className="mb-4 text-lg font-bold text-neutral-900">Choosing a Power Station for Your RV</h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    title: '30A vs 50A Service',
+                    items: [
+                      'Most RVs use 30A (3,600W) service',
+                      '50A RVs need 240V split-phase',
+                      'Check outlet type: TT-30 (30A) vs NEMA 14-50 (50A)',
+                      'Inverter must exceed 3,600W to fully support 30A loads',
+                    ],
+                  },
+                  {
+                    title: 'Solar for RV Use',
+                    items: [
+                      '800W+ solar input recommended for full-day use',
+                      'Dual solar ports allow mixed panel configurations',
+                      'MPPT charge controllers maximize efficiency',
+                      'Budget 200W of panels per 1,000Wh of battery capacity',
+                    ],
+                  },
+                ].map((section) => (
+                  <div key={section.title}>
+                    <h3 className="mb-2 text-sm font-semibold text-primary">{section.title}</h3>
+                    <ul className="space-y-1">
+                      {section.items.map((item) => (
+                        <li key={item} className="text-xs text-neutral-600">• {item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </main>
+
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Jump To</h3>
+              <ul className="space-y-2 text-sm">
+                {stations.slice(0, 8).map((s, i) => (
+                  <li key={s.slug}>
+                    <a href={`#rank-${i + 1}`} className="text-neutral-600 hover:text-primary">
+                      #{i + 1} {s.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-primary">30A vs 50A Guide</h3>
+              <div className="space-y-2 text-xs text-neutral-600">
+                <p><strong>30A (TT-30):</strong> 120V single-phase, 3,600W max. Used by most travel trailers and smaller Class C/B motorhomes.</p>
+                <p><strong>50A (NEMA 14-50):</strong> 240V split-phase, 12,000W max. Required for large Class A motorhomes with multiple AC units.</p>
+                <p>Verify your RV&apos;s shore power cord before purchasing — the pedestal outlet type determines which service you need.</p>
+              </div>
+            </div>
+
+            <AdBanner adSlot={ADSENSE_CONFIG.adSlots.sidebar} adFormat="rectangle" style={{ minHeight: 250 }} className="rounded-lg" />
+
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/best/power-stations/solar-generators/page.tsx
+++ b/app/best/power-stations/solar-generators/page.tsx
@@ -1,0 +1,144 @@
+import { Metadata } from 'next';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { QuickPicks } from '@/components/QuickPicks';
+import { RankedProductCard } from '@/components/RankedProductCard';
+import { Newsletter } from '@/components/Newsletter';
+import AdBanner from '@/components/ads/AdBanner';
+import { ADSENSE_CONFIG } from '@/lib/adsense-config';
+import { getStationsByFeature, getQuickPicks } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'Best Solar Generators 2025 — Top Portable Solar Power Stations',
+  description: 'Best solar generators with high-input charging for off-grid and emergency power. Expert tested for real-world solar performance.',
+};
+
+export default function SolarGeneratorsPage() {
+  const solar = getStationsByFeature('solar');
+  const kits = getStationsByFeature('solar-kit');
+  const stations = [...solar, ...kits].filter((s, i, arr) => arr.findIndex((x) => x.slug === s.slug) === i);
+  const quickPicks = getQuickPicks(stations);
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: 'Solar Generators' },
+      ]} />
+
+      <div className="bg-gradient-to-br from-primary to-primary-dark px-6 py-10 text-white">
+        <div className="mx-auto max-w-content">
+          <SectionLabel className="text-white/70">Buying Guide</SectionLabel>
+          <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">Best Solar Generators 2025</h1>
+          <p className="mt-2 max-w-2xl text-base text-white/80">
+            Solar generators with high-input charging for off-grid and emergency power — expert tested for real-world solar performance and reliability.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {['800W+ Solar Input', 'Off-Grid Ready', 'LiFePO4 Battery'].map((tag) => (
+              <span key={tag} className="rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs text-white/90">{tag}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <QuickPicks picks={quickPicks} />
+
+            <div>
+              <SectionLabel>Ranked List</SectionLabel>
+              <div className="space-y-4">
+                {stations.map((station, i) => (
+                  <div key={station.slug}>
+                    <RankedProductCard
+                      rank={i + 1}
+                      name={station.title}
+                      href={`/articles/${station.slug}`}
+                      image={station.image}
+                      summary={station.subtitle}
+                      score={station.score}
+                      price={station.price}
+                      specs={station.specs}
+                    />
+                    {i === 2 && (
+                      <div className="mt-4">
+                        <AdBanner adSlot={ADSENSE_CONFIG.adSlots.categoryBottom} adFormat="auto" className="rounded-lg" />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-6">
+              <SectionLabel>Buying Guide</SectionLabel>
+              <h2 className="mb-4 text-lg font-bold text-neutral-900">Choosing the Best Solar Generator</h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    title: 'How to Size Your Solar Array',
+                    items: [
+                      'Match panel wattage to solar input rating',
+                      '200W panels per 1,000Wh battery is a good starting point',
+                      'Factor in your daily energy consumption',
+                      'Add 20% buffer for cloudy days and inefficiencies',
+                    ],
+                  },
+                  {
+                    title: 'MPPT vs PWM Charge Controllers',
+                    items: [
+                      'MPPT is 20-30% more efficient than PWM',
+                      'All units on this list use MPPT controllers',
+                      'PWM only makes sense for small systems under 200W',
+                      'MPPT handles varying panel voltages better',
+                    ],
+                  },
+                ].map((section) => (
+                  <div key={section.title}>
+                    <h3 className="mb-2 text-sm font-semibold text-primary">{section.title}</h3>
+                    <ul className="space-y-1">
+                      {section.items.map((item) => (
+                        <li key={item} className="text-xs text-neutral-600">• {item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </main>
+
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Jump To</h3>
+              <ul className="space-y-2 text-sm">
+                {stations.slice(0, 8).map((s, i) => (
+                  <li key={s.slug}>
+                    <a href={`#rank-${i + 1}`} className="text-neutral-600 hover:text-primary">
+                      #{i + 1} {s.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-primary">Solar Sizing Rule of Thumb</h3>
+              <div className="space-y-2 text-xs text-neutral-600">
+                <p>Plan <strong>200W of solar panels per 1,000Wh of battery capacity</strong> as a baseline.</p>
+                <p>Example: a 2,000Wh generator pairs well with 400W of panels to fully recharge in 5–6 peak sun hours.</p>
+                <p>Add 20% extra panel capacity to account for shading, angle, and seasonal variation.</p>
+              </div>
+            </div>
+
+            <AdBanner adSlot={ADSENSE_CONFIG.adSlots.sidebar} adFormat="rectangle" style={{ minHeight: 250 }} className="rounded-lg" />
+
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/best/power-stations/under-1000/page.tsx
+++ b/app/best/power-stations/under-1000/page.tsx
@@ -1,0 +1,142 @@
+import { Metadata } from 'next';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { QuickPicks } from '@/components/QuickPicks';
+import { RankedProductCard } from '@/components/RankedProductCard';
+import { Newsletter } from '@/components/Newsletter';
+import AdBanner from '@/components/ads/AdBanner';
+import { ADSENSE_CONFIG } from '@/lib/adsense-config';
+import { getStationsUnderPrice, getQuickPicks } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'Best Portable Power Stations Under $1,000 (2025)',
+  description: 'Top-rated portable power stations under $1,000 — mid-range units offering the best value per dollar.',
+};
+
+export default function Under1000Page() {
+  const stations = getStationsUnderPrice(1000);
+  const quickPicks = getQuickPicks(stations);
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: 'Under $1,000' },
+      ]} />
+
+      <div className="bg-gradient-to-br from-primary to-primary-dark px-6 py-10 text-white">
+        <div className="mx-auto max-w-content">
+          <SectionLabel className="text-white/70">Buying Guide</SectionLabel>
+          <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">Best Portable Power Stations Under $1,000</h1>
+          <p className="mt-2 max-w-2xl text-base text-white/80">
+            Top-rated mid-range power stations offering the best value per dollar — expert tested for real-world camping, backup, and off-grid use.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {['Under $1,000', 'Mid-Range', 'Best Value'].map((tag) => (
+              <span key={tag} className="rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs text-white/90">{tag}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <QuickPicks picks={quickPicks} />
+
+            <div>
+              <SectionLabel>Ranked List</SectionLabel>
+              <div className="space-y-4">
+                {stations.map((station, i) => (
+                  <div key={station.slug}>
+                    <RankedProductCard
+                      rank={i + 1}
+                      name={station.title}
+                      href={`/articles/${station.slug}`}
+                      image={station.image}
+                      summary={station.subtitle}
+                      score={station.score}
+                      price={station.price}
+                      specs={station.specs}
+                    />
+                    {i === 2 && (
+                      <div className="mt-4">
+                        <AdBanner adSlot={ADSENSE_CONFIG.adSlots.categoryBottom} adFormat="auto" className="rounded-lg" />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-6">
+              <SectionLabel>Buying Guide</SectionLabel>
+              <h2 className="mb-4 text-lg font-bold text-neutral-900">Choosing a Power Station Under $1,000</h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    title: '1kWh vs 2kWh — What\'s the Right Size?',
+                    items: [
+                      '1kWh powers a fridge for ~6 hours or laptop for ~10 charges',
+                      '2kWh doubles runtime and handles more simultaneous loads',
+                      '2kWh units typically weigh 40–55 lbs vs 20–30 lbs for 1kWh',
+                      'Most buyers at this budget land in the 1–1.5kWh sweet spot',
+                    ],
+                  },
+                  {
+                    title: 'Key Specs to Prioritize',
+                    items: [
+                      'Solar input: 600W+ for meaningful off-grid charging',
+                      'LiFePO4 chemistry for 3,000+ cycle lifespan',
+                      'USB-C 100W+ for laptop fast charging',
+                      '5+ AC outlets for multi-device setups',
+                    ],
+                  },
+                ].map((section) => (
+                  <div key={section.title}>
+                    <h3 className="mb-2 text-sm font-semibold text-primary">{section.title}</h3>
+                    <ul className="space-y-1">
+                      {section.items.map((item) => (
+                        <li key={item} className="text-xs text-neutral-600">• {item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </main>
+
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Jump To</h3>
+              <ul className="space-y-2 text-sm">
+                {stations.slice(0, 8).map((s, i) => (
+                  <li key={s.slug}>
+                    <a href={`#rank-${i + 1}`} className="text-neutral-600 hover:text-primary">
+                      #{i + 1} {s.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-primary">Capacity Guide</h3>
+              <div className="space-y-2 text-xs text-neutral-600">
+                <p><strong>500Wh:</strong> Weekend camping trip. Charges phones, runs a fan, powers a small light.</p>
+                <p><strong>1,000Wh:</strong> Extended camping or day-long outages. Runs a mini-fridge for ~6 hours.</p>
+                <p><strong>2,000Wh:</strong> Home backup essentials. Powers a refrigerator, lights, and device charging overnight.</p>
+              </div>
+            </div>
+
+            <AdBanner adSlot={ADSENSE_CONFIG.adSlots.sidebar} adFormat="rectangle" style={{ minHeight: 250 }} className="rounded-lg" />
+
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/best/power-stations/under-500/page.tsx
+++ b/app/best/power-stations/under-500/page.tsx
@@ -1,0 +1,141 @@
+import { Metadata } from 'next';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { QuickPicks } from '@/components/QuickPicks';
+import { RankedProductCard } from '@/components/RankedProductCard';
+import { Newsletter } from '@/components/Newsletter';
+import AdBanner from '@/components/ads/AdBanner';
+import { ADSENSE_CONFIG } from '@/lib/adsense-config';
+import { getStationsUnderPrice, getQuickPicks } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'Best Portable Power Stations Under $500 (2025)',
+  description: 'The best portable power stations under $500 — expert tested for value, reliability, and real-world performance.',
+};
+
+export default function Under500Page() {
+  const stations = getStationsUnderPrice(500);
+  const quickPicks = getQuickPicks(stations);
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: 'Under $500' },
+      ]} />
+
+      <div className="bg-gradient-to-br from-primary to-primary-dark px-6 py-10 text-white">
+        <div className="mx-auto max-w-content">
+          <SectionLabel className="text-white/70">Buying Guide</SectionLabel>
+          <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">Best Portable Power Stations Under $500</h1>
+          <p className="mt-2 max-w-2xl text-base text-white/80">
+            Expert-tested portable power stations under $500 — ranked for value, reliability, and real-world performance at every price tier.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {['Under $500', 'Best Value', 'Expert Tested'].map((tag) => (
+              <span key={tag} className="rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs text-white/90">{tag}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <QuickPicks picks={quickPicks} />
+
+            <div>
+              <SectionLabel>Ranked List</SectionLabel>
+              <div className="space-y-4">
+                {stations.map((station, i) => (
+                  <div key={station.slug}>
+                    <RankedProductCard
+                      rank={i + 1}
+                      name={station.title}
+                      href={`/articles/${station.slug}`}
+                      image={station.image}
+                      summary={station.subtitle}
+                      score={station.score}
+                      price={station.price}
+                      specs={station.specs}
+                    />
+                    {i === 2 && (
+                      <div className="mt-4">
+                        <AdBanner adSlot={ADSENSE_CONFIG.adSlots.categoryBottom} adFormat="auto" className="rounded-lg" />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-6">
+              <SectionLabel>Buying Guide</SectionLabel>
+              <h2 className="mb-4 text-lg font-bold text-neutral-900">Choosing a Power Station Under $500</h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    title: 'What You Get at Each Price Point',
+                    items: [
+                      '$99–$199: USB/DC only, 100–200Wh, no AC outlet',
+                      '$200–$350: Small AC outlet, 200–400Wh, limited ports',
+                      '$350–$500: 500–700Wh, proper AC outlets, solar input',
+                    ],
+                  },
+                  {
+                    title: 'Budget vs Mid-Range Trade-offs',
+                    items: [
+                      'Budget units often use Li-ion vs LiFePO4 (shorter lifespan)',
+                      'Fewer AC outlets and lower wattage output',
+                      'Solar input often proprietary or absent',
+                      'Warranty typically shorter (1 year vs 2–5 years)',
+                    ],
+                  },
+                ].map((section) => (
+                  <div key={section.title}>
+                    <h3 className="mb-2 text-sm font-semibold text-primary">{section.title}</h3>
+                    <ul className="space-y-1">
+                      {section.items.map((item) => (
+                        <li key={item} className="text-xs text-neutral-600">• {item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </main>
+
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Jump To</h3>
+              <ul className="space-y-2 text-sm">
+                {stations.slice(0, 8).map((s, i) => (
+                  <li key={s.slug}>
+                    <a href={`#rank-${i + 1}`} className="text-neutral-600 hover:text-primary">
+                      #{i + 1} {s.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-primary">Price Band Comparison</h3>
+              <div className="space-y-2 text-xs text-neutral-600">
+                <p><strong>$99–$199:</strong> USB and DC only, 100–200Wh. Good for charging phones and small devices.</p>
+                <p><strong>$200–$350:</strong> Small AC outlet, 200–400Wh. Powers small appliances for short periods.</p>
+                <p><strong>$350–$500:</strong> 500–700Wh with proper AC outlets and solar input. Handles real-world camping loads.</p>
+              </div>
+            </div>
+
+            <AdBanner adSlot={ADSENSE_CONFIG.adSlots.sidebar} adFormat="rectangle" style={{ minHeight: 250 }} className="rounded-lg" />
+
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/best/power-stations/van-life/page.tsx
+++ b/app/best/power-stations/van-life/page.tsx
@@ -1,0 +1,147 @@
+import { Metadata } from 'next';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { QuickPicks } from '@/components/QuickPicks';
+import { RankedProductCard } from '@/components/RankedProductCard';
+import { Newsletter } from '@/components/Newsletter';
+import AdBanner from '@/components/ads/AdBanner';
+import { ADSENSE_CONFIG } from '@/lib/adsense-config';
+import { getStationsByFeature, getQuickPicks } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'Best Power Stations for Van Life 2025',
+  description: 'Best power stations for van life — compact, solar-capable, and under 30 lbs. Expert tested for life on the road.',
+};
+
+export default function VanLifePage() {
+  const stations = getStationsByFeature('van-life');
+  const quickPicks = getQuickPicks(stations);
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: 'Van Life' },
+      ]} />
+
+      <div className="bg-gradient-to-br from-primary to-primary-dark px-6 py-10 text-white">
+        <div className="mx-auto max-w-content">
+          <SectionLabel className="text-white/70">Buying Guide</SectionLabel>
+          <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">Best Power Stations for Van Life 2025</h1>
+          <p className="mt-2 max-w-2xl text-base text-white/80">
+            Compact, solar-capable power stations under 30 lbs — expert tested for life on the road, off-grid adventures, and full-time van dwelling.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {['Under 30 lbs', 'Solar Capable', 'Compact'].map((tag) => (
+              <span key={tag} className="rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs text-white/90">{tag}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <QuickPicks picks={quickPicks} />
+
+            <div>
+              <SectionLabel>Ranked List</SectionLabel>
+              <div className="space-y-4">
+                {stations.map((station, i) => (
+                  <div key={station.slug}>
+                    <RankedProductCard
+                      rank={i + 1}
+                      name={station.title}
+                      href={`/articles/${station.slug}`}
+                      image={station.image}
+                      summary={station.subtitle}
+                      score={station.score}
+                      price={station.price}
+                      specs={station.specs}
+                    />
+                    {i === 2 && (
+                      <div className="mt-4">
+                        <AdBanner adSlot={ADSENSE_CONFIG.adSlots.categoryBottom} adFormat="auto" className="rounded-lg" />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-6">
+              <SectionLabel>Buying Guide</SectionLabel>
+              <h2 className="mb-4 text-lg font-bold text-neutral-900">Choosing a Power Station for Van Life</h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    title: 'How to Size for Van Life',
+                    items: [
+                      'Calculate daily watt-hours: add up all device loads × hours used',
+                      'Typical van setup: 800–1,500Wh per day',
+                      'Size battery to 2–3 days of use without solar',
+                      'Plan solar to cover daily use + 20% for inefficiencies',
+                    ],
+                  },
+                  {
+                    title: 'Solar vs Shore Power Strategy',
+                    items: [
+                      'Solar handles daily use in good sun conditions',
+                      'Shore power (campground hookups) fills gaps on cloudy days',
+                      'DC-DC charging from alternator supplements both',
+                      '400–800W of solar covers most van life daily needs',
+                    ],
+                  },
+                ].map((section) => (
+                  <div key={section.title}>
+                    <h3 className="mb-2 text-sm font-semibold text-primary">{section.title}</h3>
+                    <ul className="space-y-1">
+                      {section.items.map((item) => (
+                        <li key={item} className="text-xs text-neutral-600">• {item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </main>
+
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Jump To</h3>
+              <ul className="space-y-2 text-sm">
+                {stations.slice(0, 8).map((s, i) => (
+                  <li key={s.slug}>
+                    <a href={`#rank-${i + 1}`} className="text-neutral-600 hover:text-primary">
+                      #{i + 1} {s.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-primary">Van Power Budget</h3>
+              <div className="space-y-1.5 text-xs text-neutral-600">
+                <p>Typical daily van power draw:</p>
+                <div className="mt-1 space-y-0.5">
+                  <p>Fridge: <strong>50W</strong> × 24h = 1,200Wh</p>
+                  <p>Lights: <strong>20W</strong> × 5h = 100Wh</p>
+                  <p>Laptop: <strong>60W</strong> × 4h = 240Wh</p>
+                  <p>Misc: <strong>20W</strong> × 5h = 100Wh</p>
+                </div>
+                <p className="mt-2 font-medium">Total: ~1,050Wh/day. Size your battery to 2,000–3,000Wh for 2–3 days of autonomy.</p>
+              </div>
+            </div>
+
+            <AdBanner adSlot={ADSENSE_CONFIG.adSlots.sidebar} adFormat="rectangle" style={{ minHeight: 250 }} className="rounded-lg" />
+
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds 7 new power station category pages organised by buyer use case rather than spec tier, targeting high-volume search queries that the existing 4 pages don't address.

## Details
- All pages pull live data from `lib/power-station-data.ts` — no hardcoded product lists
- Pages use existing components: `QuickPicks`, `RankedProductCard`, `Breadcrumb`, `SectionLabel`, `Newsletter`, `AdBanner`
- Each page has a unique sidebar widget and buying guide section

**New pages:**
- `/best/power-stations/rv-power-stations` → `getStationsByFeature('30a-rv')` — sidebar: 30A vs 50A guide
- `/best/power-stations/solar-generators` → solar + solar-kit union — sidebar: solar sizing rule of thumb
- `/best/power-stations/under-500` → `getStationsUnderPrice(500)` — sidebar: price band comparison
- `/best/power-stations/under-1000` → `getStationsUnderPrice(1000)` — sidebar: capacity guide
- `/best/power-stations/for-cpap` → `getStationsByFeature('cpap')` — sidebar: CPAP runtime table
- `/best/power-stations/240v-power-stations` → `getStationsByFeature('240v')` — sidebar: 240V appliance wattage table
- `/best/power-stations/van-life` → `getStationsByFeature('van-life')` — sidebar: van power budget guide

## Testing Done
- [ ] All 7 routes render as `○ (Static)` in build output
- [ ] `npm run type-check` clean
- [ ] Existing 4 category pages unaffected