### PR TITLE
feat(pages): add ComparisonCard component and 3 model-vs-model comparison pages

### DIFF
--- a/app/best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2/page.tsx
+++ b/app/best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2/page.tsx
@@ -1,0 +1,55 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { ComparisonCard } from '@/components/ComparisonCard';
+import { Newsletter } from '@/components/Newsletter';
+import { getStationsBySlugs } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'Bluetti Elite 200 V2 vs Anker SOLIX C2000 Gen 2: Which Should You Buy? (2025)',
+  description: 'Side-by-side comparison of the Bluetti Elite 200 V2 and Anker SOLIX C2000 Gen 2. Expert analysis of efficiency, solar input, and value.',
+};
+
+export default function CompareBluettiElite200V2VsAnkerC2000Gen2() {
+  const [a, b] = getStationsBySlugs(['bluetti_elite_200_v2', 'anker_solix_c2000_gen2']);
+  if (!a || !b) return null;
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: 'Compare' },
+        { label: 'Elite 200 V2 vs C2000 Gen 2' },
+      ]} />
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <div>
+              <SectionLabel>Head-to-Head</SectionLabel>
+              <h1 className="text-2xl font-extrabold text-neutral-900 mb-6">Bluetti Elite 200 V2 vs Anker SOLIX C2000 Gen 2</h1>
+              <ComparisonCard
+                a={a}
+                b={b}
+                verdict="The Bluetti Elite 200 V2 wins on efficiency (94% vs 89%) and solar input (1,000W vs 800W) — the right pick if you cycle daily or rely heavily on solar. The Anker SOLIX C2000 Gen 2 wins on price ($799 vs $1,099), display quality, outlet count, and weight — the better all-rounder for most buyers. If budget is the priority, Anker wins clearly."
+                buyA={a.retailerLinks?.Amazon ?? '#'}
+                buyB={b.retailerLinks?.Amazon ?? '#'}
+              />
+            </div>
+          </main>
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Also Compare</h3>
+              <ul className="space-y-2 text-sm">
+                <li><Link href="/best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000" className="text-neutral-600 hover:text-primary">EcoFlow Delta 3 Plus vs Anker SOLIX C1000 →</Link></li>
+                <li><Link href="/best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10" className="text-neutral-600 hover:text-primary">EcoFlow Delta Pro Ultra X vs Anker SOLIX E10 →</Link></li>
+              </ul>
+            </div>
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000/page.tsx
+++ b/app/best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000/page.tsx
@@ -1,0 +1,55 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { ComparisonCard } from '@/components/ComparisonCard';
+import { Newsletter } from '@/components/Newsletter';
+import { getStationsBySlugs } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'EcoFlow Delta 3 Plus vs Anker SOLIX C1000: Which Should You Buy? (2025)',
+  description: 'Side-by-side comparison of the EcoFlow Delta 3 Plus and Anker SOLIX C1000. Expert analysis of specs, performance, and value.',
+};
+
+export default function CompareEcoflowDelta3PlusVsAnkerC1000() {
+  const [a, b] = getStationsBySlugs(['ecoflow_delta_3_plus', 'anker_solix_c1000']);
+  if (!a || !b) return null;
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: 'Compare' },
+        { label: 'Delta 3 Plus vs C1000' },
+      ]} />
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <div>
+              <SectionLabel>Head-to-Head</SectionLabel>
+              <h1 className="text-2xl font-extrabold text-neutral-900 mb-6">EcoFlow Delta 3 Plus vs Anker SOLIX C1000</h1>
+              <ComparisonCard
+                a={a}
+                b={b}
+                verdict="The EcoFlow Delta 3 Plus wins on UPS functionality, X-Boost technology, and ecosystem depth — worth the premium for home backup users who need smart home integration. The Anker SOLIX C1000 Gen 2 wins on value: nearly identical capacity at $449 with faster charging and better solar input. For most buyers prioritizing cost, Anker is the smarter choice."
+                buyA={a.retailerLinks?.Amazon ?? '#'}
+                buyB={b.retailerLinks?.Amazon ?? '#'}
+              />
+            </div>
+          </main>
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Also Compare</h3>
+              <ul className="space-y-2 text-sm">
+                <li><Link href="/best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2" className="text-neutral-600 hover:text-primary">Bluetti Elite 200 V2 vs Anker C2000 Gen 2 →</Link></li>
+                <li><Link href="/best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10" className="text-neutral-600 hover:text-primary">EcoFlow Delta Pro Ultra X vs Anker SOLIX E10 →</Link></li>
+              </ul>
+            </div>
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10/page.tsx
+++ b/app/best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10/page.tsx
@@ -1,0 +1,55 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { ComparisonCard } from '@/components/ComparisonCard';
+import { Newsletter } from '@/components/Newsletter';
+import { getStationsBySlugs } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'EcoFlow Delta Pro Ultra X vs Anker SOLIX E10: Which Whole-Home System Wins? (2025)',
+  description: 'Side-by-side comparison of the EcoFlow Delta Pro Ultra X and Anker SOLIX E10 whole-home backup systems. Expert analysis.',
+};
+
+export default function CompareEcoflowDeltaProUltraXVsAnkerSolixE10() {
+  const [a, b] = getStationsBySlugs(['ecoflow_delta_pro_ultra_x', 'anker_solix_e10']);
+  if (!a || !b) return null;
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: 'Compare' },
+        { label: 'Delta Pro Ultra X vs SOLIX E10' },
+      ]} />
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <div>
+              <SectionLabel>Head-to-Head</SectionLabel>
+              <h1 className="text-2xl font-extrabold text-neutral-900 mb-6">EcoFlow Delta Pro Ultra X vs Anker SOLIX E10</h1>
+              <ComparisonCard
+                a={a}
+                b={b}
+                verdict="The EcoFlow Delta Pro Ultra X wins on raw inverter power (12kW vs 7.6kW) and solar input (10kW vs 9kW), making it the choice for the largest residential solar arrays. The Anker SOLIX E10 wins on installation simplicity (wireless battery connections), silent operation (passive cooling), and surge capacity (37kW vs inconsistent EcoFlow surge handling). For most homeowners, the Anker's installation advantage makes it the better choice."
+                buyA={a.retailerLinks?.Amazon ?? '#'}
+                buyB={b.retailerLinks?.Amazon ?? '#'}
+              />
+            </div>
+          </main>
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Also Compare</h3>
+              <ul className="space-y-2 text-sm">
+                <li><Link href="/best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000" className="text-neutral-600 hover:text-primary">EcoFlow Delta 3 Plus vs Anker SOLIX C1000 →</Link></li>
+                <li><Link href="/best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2" className="text-neutral-600 hover:text-primary">Bluetti Elite 200 V2 vs Anker C2000 Gen 2 →</Link></li>
+              </ul>
+            </div>
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ComparisonCard.tsx
+++ b/components/ComparisonCard.tsx
@@ -1,0 +1,99 @@
+// components/ComparisonCard.tsx
+import { PowerStationEntry } from '@/lib/power-station-data';
+import { OptimizedImage } from './OptimizedImage';
+import { ScoreBadge } from './ScoreBadge';
+
+interface ComparisonCardProps {
+  a: PowerStationEntry;
+  b: PowerStationEntry;
+  verdict: string;
+  buyA: string;
+  buyB: string;
+}
+
+type SpecRow = { label: string; keyA: string; keyB: string; higherIsBetter: boolean };
+
+const SPEC_ROWS: SpecRow[] = [
+  { label: 'Capacity', keyA: 'Battery Capacity', keyB: 'Battery Capacity', higherIsBetter: true },
+  { label: 'Inverter', keyA: 'Inverter Power', keyB: 'Inverter Power', higherIsBetter: true },
+  { label: 'Solar Input', keyA: 'Solar Input', keyB: 'Solar Input', higherIsBetter: true },
+  { label: 'Weight', keyA: 'Weight', keyB: 'Weight', higherIsBetter: false },
+  { label: 'Efficiency', keyA: 'Efficiency', keyB: 'Efficiency', higherIsBetter: true },
+];
+
+function extractNum(val: string | undefined): number {
+  if (!val) return 0;
+  const match = val.replace(/,/g, '').match(/[\d.]+/);
+  return match ? parseFloat(match[0]) : 0;
+}
+
+export function ComparisonCard({ a, b, verdict, buyA, buyB }: ComparisonCardProps) {
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white overflow-hidden">
+      {/* Header */}
+      <div className="grid grid-cols-2 divide-x divide-neutral-200">
+        {[{ entry: a, buyUrl: buyA }, { entry: b, buyUrl: buyB }].map(({ entry, buyUrl }) => (
+          <div key={entry.slug} className="p-5 flex flex-col items-center text-center gap-3">
+            <div className="relative h-32 w-full">
+              <OptimizedImage src={entry.image} alt={entry.title} fill sizes="250px" className="object-contain" />
+            </div>
+            <h3 className="font-bold text-neutral-900 text-sm">{entry.title}</h3>
+            <div className="flex items-center gap-2">
+              <ScoreBadge score={entry.score} showLabel />
+              <span className="font-bold text-neutral-900">{entry.price}</span>
+            </div>
+            <a href={buyUrl} target="_blank" rel="noopener noreferrer nofollow"
+              className="inline-flex items-center rounded-md bg-accent px-4 py-1.5 text-xs font-semibold text-white hover:bg-accent/90">
+              Buy Now →
+            </a>
+          </div>
+        ))}
+      </div>
+
+      {/* Spec table */}
+      <div className="border-t border-neutral-200">
+        <table className="w-full text-xs">
+          <tbody>
+            {SPEC_ROWS.map((row) => {
+              const valA = a.specs?.[row.keyA] ?? '—';
+              const valB = b.specs?.[row.keyB] ?? '—';
+              const numA = extractNum(valA);
+              const numB = extractNum(valB);
+              const aWins = numA !== numB && (row.higherIsBetter ? numA > numB : numA < numB);
+              const bWins = numA !== numB && (row.higherIsBetter ? numB > numA : numB < numA);
+              return (
+                <tr key={row.label} className="border-t border-neutral-100">
+                  <td className={`px-4 py-2.5 font-medium ${aWins ? 'bg-green-50 text-green-700' : 'text-neutral-700'}`}>{valA}</td>
+                  <td className="px-4 py-2.5 text-center text-neutral-400 text-[10px] font-semibold uppercase">{row.label}</td>
+                  <td className={`px-4 py-2.5 font-medium text-right ${bWins ? 'bg-green-50 text-green-700' : 'text-neutral-700'}`}>{valB}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pros / Cons */}
+      <div className="grid grid-cols-2 divide-x divide-neutral-200 border-t border-neutral-200">
+        {[a, b].map((entry) => (
+          <div key={entry.slug} className="p-4 space-y-2">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-green-600 mb-1">Pros</p>
+              <ul className="space-y-0.5">{entry.pros.slice(0, 3).map((p) => <li key={p} className="text-xs text-neutral-600">+ {p}</li>)}</ul>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-red-500 mb-1">Cons</p>
+              <ul className="space-y-0.5">{entry.cons.slice(0, 3).map((c) => <li key={c} className="text-xs text-neutral-600">− {c}</li>)}</ul>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Verdict */}
+      <div className="border-t border-neutral-200 bg-primary-lightest/40 p-5">
+        <p className="text-xs font-semibold uppercase tracking-wide text-primary mb-2">Verdict</p>
+        <p className="text-sm text-neutral-700 leading-relaxed">{verdict}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a reusable `ComparisonCard` component and 3 high-intent comparison pages targeting buyers in the final decision stage between two specific models.

## Details
**`components/ComparisonCard.tsx`:**
- Side-by-side layout: product image, score, price, buy button per column
- Spec table: Capacity, Inverter, Solar Input, Weight, Efficiency — winner highlighted green per row via numeric extraction
- Pros/cons columns (top 3 each from frontmatter)
- Verdict section at the bottom
- Data sourced entirely from `getStationsBySlugs()` — no hardcoded specs

**Comparison pages (all `○ Static`):**
- `/best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000`
- `/best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2`
- `/best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10`

Each page includes cross-links to the other 2 comparisons in the sidebar.

## Testing Done
- [ ] All 3 comparison routes render as `○ (Static)`
- [ ] Green winner highlighting works correctly (Weight: lower wins; all others: higher wins)
- [ ] `npm run type-check` clean