### PR TITLE
feat(hub): wire PowerStationQuiz and update category grid to 11 categories

### DIFF
--- a/app/best/power-stations/page.tsx
+++ b/app/best/power-stations/page.tsx
@@ -5,6 +5,7 @@ import { SectionLabel } from '@/components/SectionLabel';
 import { Newsletter } from '@/components/Newsletter';
 import AdBanner from '@/components/ads/AdBanner';
 import { ADSENSE_CONFIG } from '@/lib/adsense-config';
+import { PowerStationQuiz } from '@/components/PowerStationQuiz';
 
 export const metadata: Metadata = {
   title: 'Best Power Stations 2025 - Expert Reviews & Buying Guides',
@@ -12,38 +13,17 @@ export const metadata: Metadata = {
 };
 
 const powerStationCategories = [
-  {
-    title: 'Portable Power Stations',
-    description: 'Versatile power stations for camping, emergencies, and outdoor activities',
-    href: '/best/power-stations/portable-power-stations',
-    count: 7,
-    priceRange: '$299 – $3,999',
-    features: ['500Wh – 3000Wh capacity', 'Multiple output ports', 'Solar charging', 'Portable design'],
-  },
-  {
-    title: 'House Backup Power Stations',
-    description: 'High-capacity units for whole-home backup during outages',
-    href: '/best/power-stations/house-backup-power-stations',
-    count: 4,
-    priceRange: '$2,999 – $8,999',
-    features: ['3000Wh+ capacity', 'Home integration', 'Transfer switches', 'Extended runtime'],
-  },
-  {
-    title: 'Camping Power Stations',
-    description: 'Compact and lightweight power solutions for outdoor adventures',
-    href: '/best/power-stations/camping-power-stations',
-    count: 5,
-    priceRange: '$199 – $1,499',
-    features: ['200Wh – 1000Wh capacity', 'Ultra-portable', 'Weather resistant', 'Silent operation'],
-  },
-  {
-    title: 'Carry-On Power Stations',
-    description: 'TSA-approved power banks for travel and airline carry-on',
-    href: '/best/power-stations/carry-on-power-stations',
-    count: 3,
-    priceRange: '$99 – $399',
-    features: ['Under 100Wh capacity', 'TSA compliant', 'Compact design', 'Fast charging'],
-  },
+  { title: 'Portable Power Stations', description: 'Versatile power stations for camping, emergencies, and outdoor activities', href: '/best/power-stations/portable-power-stations', count: 10, priceRange: '$299 – $1,499', features: ['500Wh – 1,500Wh', 'Multiple ports', 'Solar charging', 'Portable design'] },
+  { title: 'House Backup Power Stations', description: 'High-capacity units for whole-home backup during outages', href: '/best/power-stations/house-backup-power-stations', count: 10, priceRange: '$1,199 – $7,699', features: ['3,000Wh+', 'Home integration', '240V capable', 'Extended runtime'] },
+  { title: 'RV Power Stations', description: 'Power stations with genuine 30A outlets and solar charging for RV and trailer use', href: '/best/power-stations/rv-power-stations', count: 8, priceRange: '$1,011 – $7,699', features: ['30A RV outlet', 'Solar ready', 'High capacity', 'Expandable'] },
+  { title: 'Solar Generators', description: 'High solar input units for off-grid and solar-primary setups', href: '/best/power-stations/solar-generators', count: 12, priceRange: '$399 – $7,699', features: ['800W+ solar', 'LiFePO4 battery', 'Off-grid ready', 'MPPT charging'] },
+  { title: 'Camping Power Stations', description: 'Compact and lightweight power solutions for outdoor adventures', href: '/best/power-stations/camping-power-stations', count: 6, priceRange: '$199 – $999', features: ['200Wh – 1,000Wh', 'Ultra-portable', 'Weather resistant', 'Silent operation'] },
+  { title: 'Van Life Power Stations', description: 'Compact, solar-capable units under 30 lbs built for life on the road', href: '/best/power-stations/van-life', count: 7, priceRange: '$399 – $1,099', features: ['Under 30 lbs', 'Solar capable', 'Compact', 'DC output'] },
+  { title: 'Under $500', description: 'Best portable power stations for every budget under $500', href: '/best/power-stations/under-500', count: 6, priceRange: '$99 – $499', features: ['Budget friendly', 'Essential features', 'Portable', 'Reliable brands'] },
+  { title: 'Under $1,000', description: 'Mid-range power stations offering the best value per dollar', href: '/best/power-stations/under-1000', count: 14, priceRange: '$299 – $999', features: ['Best value', 'Mid-range', '500Wh – 2,000Wh', 'Expert picks'] },
+  { title: '240V Power Stations', description: 'Power stations with split-phase 240V output for dryers, AC, and EV charging', href: '/best/power-stations/240v-power-stations', count: 5, priceRange: '$1,199 – $7,699', features: ['240V output', 'Split-phase', 'Heavy loads', 'Home backup'] },
+  { title: 'CPAP Power Stations', description: 'Quiet, lightweight power stations with enough capacity for overnight CPAP use', href: '/best/power-stations/for-cpap', count: 6, priceRange: '$299 – $999', features: ['500–1,500Wh', 'Quiet operation', 'DC mode', 'Compact'] },
+  { title: 'Carry-On Power Stations', description: 'TSA-approved power banks for travel and airline carry-on', href: '/best/power-stations/carry-on-power-stations', count: 3, priceRange: '$99 – $399', features: ['Under 100Wh', 'TSA compliant', 'Compact design', 'Fast charging'] },
 ];
 
 export default function PowerStationsHub() {
@@ -59,7 +39,7 @@ export default function PowerStationsHub() {
             Expert-tested portable power solutions for every need and budget. 19+ models tested for performance, reliability, and value.
           </p>
           <div className="mt-4 flex flex-wrap gap-2">
-            {['19+ Models Tested', 'Real-World Performance', 'All Budgets Covered'].map((tag) => (
+            {['33+ Models Tested', 'Real-World Performance', 'All Budgets Covered'].map((tag) => (
               <span key={tag} className="rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs text-white/90">{tag}</span>
             ))}
           </div>
@@ -69,6 +49,7 @@ export default function PowerStationsHub() {
       <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
           <main className="space-y-6">
+            <PowerStationQuiz />
             <div>
               <SectionLabel>Categories</SectionLabel>
               <div className="space-y-4">
@@ -127,6 +108,15 @@ export default function PowerStationsHub() {
           </main>
 
           <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Compare Models</h3>
+              <ul className="space-y-2 text-sm">
+                <li><Link href="/best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000" className="text-neutral-600 hover:text-primary text-xs">EcoFlow Delta 3 Plus vs Anker C1000 →</Link></li>
+                <li><Link href="/best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2" className="text-neutral-600 hover:text-primary text-xs">Bluetti Elite 200 V2 vs Anker C2000 →</Link></li>
+                <li><Link href="/best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10" className="text-neutral-600 hover:text-primary text-xs">EcoFlow Delta Pro Ultra X vs Anker E10 →</Link></li>
+              </ul>
+            </div>
+
             <div className="rounded-xl border border-neutral-200 bg-white p-4">
               <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Jump To</h3>
               <ul className="space-y-2 text-sm">


### PR DESCRIPTION
## Summary
Updates the power station hub page (`/best/power-stations`) to surface the new finder quiz, expand the category grid from 4 to 11 entries, and add a model comparison sidebar — completing the full engagement feature set.

## Details
- Added `<PowerStationQuiz />` as the first element in `<main>`, above the category grid
- Expanded `powerStationCategories` from 4 items to 11 (adds RV, Solar Generators, Van Life, Under $500, Under $1000, 240V, CPAP)
- Updated hero tag from `'19+ Models Tested'` → `'33+ Models Tested'`
- Added "Compare Models" sidebar widget with links to all 3 comparison pages

## Testing Done
- [ ] Hub page renders as `○ (Static)` in build output
- [ ] Quiz appears above category grid
- [ ] All 11 category links resolve to existing pages
- [ ] `npm run type-check` clean