### PR TITLE
docs: add audience-organized codebase documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,47 @@
+# ProductLabR Documentation
+
+> Editorial product-review site built on Next.js App Router. 101 markdown reviews across 10 categories, statically exported to GitHub Pages, monetized through AdSense and affiliate links.
+
+This documentation is organized by **who you are** and **what you're trying to do** — pick the entry point that matches your role.
+
+---
+
+## Start here
+
+| If you are a… | Read this | You'll learn |
+|---|---|---|
+| 🧭 **First-time visitor** | [overview.md](./overview.md) | What the product is, how it makes money, what's on the roadmap |
+| 📊 **Product Manager** | [for-product-managers.md](./for-product-managers.md) | Information architecture, category strategy, monetization model, success metrics |
+| 💻 **Developer** | [for-developers.md](./for-developers.md) | Local setup, routing, data layer, deployment, contribution workflow |
+| 🎨 **Designer** | [for-designers.md](./for-designers.md) | Design tokens, typography, component anatomy, motion language |
+| ✍️ **Content editor** | [for-content-editors.md](./for-content-editors.md) | How to write a review, frontmatter schema, image rules, publishing |
+
+## Reference
+
+Deep technical references — open when you need exact field names, route paths, or component props.
+
+- **[architecture.md](./architecture.md)** — System architecture, data flow, rendering model
+- **[reference/content-schema.md](./reference/content-schema.md)** — Full frontmatter schema for `posts/*.md`
+- **[reference/components.md](./reference/components.md)** — Component catalog with props
+- **[reference/routes.md](./reference/routes.md)** — Complete route map
+
+## Operational guides
+
+These live at the repo root because they were authored before this docs tree existed. Linked here for discoverability.
+
+- **[PRODUCTION.md](../PRODUCTION.md)** — Deployment checklist, performance targets, post-deploy validation
+- **[ADSENSE_SETUP.md](../ADSENSE_SETUP.md)** — How to wire AdSense in production
+- **[BEST_SECTION_README.md](../BEST_SECTION_README.md)** — Background on the "Best of" hub
+
+## Active work
+
+In-flight specs and plans live under `docs/superpowers/`:
+
+- **Spec:** [Power Station Categories Design](./superpowers/specs/2025-05-06-power-station-categories-design.md)
+- **Plan:** [Power Station Category Expansion](./superpowers/plans/2025-05-06-power-station-category-expansion.md)
+
+---
+
+## Documentation philosophy
+
+This tree follows the [Diátaxis](https://diataxis.fr/) split between *explanation* (the audience guides), *reference* (`reference/`), and *how-to* (the operational guides above). If you add a doc, ask which quadrant it belongs in before placing it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,181 @@
+# Architecture
+
+A single-page deep dive on how ProductLabR is built and why. Read [overview.md](./overview.md) first for the executive summary.
+
+## Rendering model
+
+**Build-time static rendering.** Every route is materialized to HTML during `next build`, written to `./out/`, and served by GitHub Pages.
+
+- No Node runtime in production.
+- No `getServerSideProps`, no edge functions, no ISR.
+- Dynamic routes (`/articles/[slug]`, `/best/.../compare/[pair]`) enumerate their params with `generateStaticParams()`.
+- Pages that Next would otherwise treat as dynamic (`sitemap.ts`, `robots.ts`) are pinned with `export const dynamic = 'force-static'`.
+
+This constraint is the single most important fact about the architecture. Anything personalized has to run **client-side** (`'use client'` islands).
+
+## Data flow
+
+```
+┌──────────────────┐
+│  posts/*.md      │   YAML frontmatter + markdown body
+└────────┬─────────┘
+         │ read at build time
+         ▼
+┌──────────────────────────────────────────┐
+│  lib/Posts.ts (React.cache())            │
+│   getPostBySlug, getAllPostSlugs,        │
+│   getPostsByCategory                     │
+└────────┬─────────────────────────────────┘
+         │
+         ▼
+┌──────────────────────────────────────────┐
+│  Vertical-specific data layer            │
+│   lib/power-station-data.ts              │
+│   typed entries + filter functions       │
+└────────┬─────────────────────────────────┘
+         │
+         ▼
+┌──────────────────────────────────────────┐
+│  app/**/page.tsx (RSC)                   │
+│   - generateStaticParams()               │
+│   - generateMetadata() per route         │
+│   - returns JSX tree of server + client  │
+│     components                           │
+└────────┬─────────────────────────────────┘
+         │
+         ▼
+┌──────────────────────────────────────────┐
+│  marked + lib/markdown.ts                │
+│   markdown body → Tailwind-styled HTML   │
+└────────┬─────────────────────────────────┘
+         │
+         ▼
+┌──────────────────────────────────────────┐
+│  next build → ./out/ (static files)      │
+└────────┬─────────────────────────────────┘
+         │
+         ▼
+┌──────────────────────────────────────────┐
+│  GitHub Actions → GitHub Pages           │
+└──────────────────────────────────────────┘
+```
+
+## Why React Server Components
+
+- The vast majority of components have no interactivity. Rendering them as RSC keeps the client bundle small.
+- Markdown parsing and frontmatter reads happen on the server side of the build — they never ship to the browser.
+- Interactive islands (`PowerStationQuiz`, `SearchBar`, `StickyBuyBar`) opt-in with `'use client'`.
+
+## The data layer
+
+Two-tier:
+
+1. **`lib/Posts.ts`** — generic markdown loader. Knows how to read `posts/<category>/<slug>.md`, validate slugs, parse frontmatter, and list categories. Cached with `React.cache()`.
+2. **Vertical-specific helpers** — e.g. `lib/power-station-data.ts` exposes a typed `PowerStationEntry[]` plus filter functions (`getStationsByFeature`, `getStationsUnderPrice`, `getStationsBySlugs`, `getQuickPicks`). New verticals should follow this pattern: lift filtering logic out of route files into a typed helper, and import it from every page that needs the data.
+
+**Why a vertical-specific layer instead of generic queries?** Filters are domain-aware (power stations care about `capacityWh`; cameras would care about sensor size and mount type). Generic ORM-style queries would push that complexity into every page.
+
+## Routing
+
+App Router, file-system based. Three flavors:
+
+| Flavor | Example | Pre-rendered via |
+|---|---|---|
+| Fully static | `app/best/page.tsx` | Default — no params to enumerate |
+| Static with dynamic params | `app/articles/[slug]/page.tsx` | `generateStaticParams()` returns every slug |
+| Static via override | `app/sitemap.ts`, `app/robots.ts` | `export const dynamic = 'force-static'` |
+
+Article metadata (OG tags, JSON-LD) is generated per-route with `generateMetadata()`. This is what gets the home page and reviews crawled correctly.
+
+## Markdown pipeline
+
+Files run through `lib/markdown.ts → processMarkdownContent(content)`:
+
+1. `gray-matter` (called earlier in `lib/Posts.ts`) splits frontmatter from body.
+2. `marked` with GFM + line breaks converts markdown to HTML.
+3. A custom renderer strips raw inline HTML (XSS hardening) — markdown only.
+4. Regex pass injects Tailwind classes onto headings, lists, links, code, blockquotes, etc.
+5. H2 anchor IDs are derived from heading text, enabling the Table of Contents.
+
+The styled output drops into a `.article-body` container (defined in `styles/global.css`) for finishing touches (line-height, scroll-margin-top, etc.).
+
+## Styling architecture
+
+- **CSS variables** in `styles/theme.css` are the single source of truth for color, radius, font family, max-width.
+- **Tailwind** (`tailwind.config.ts`) extends `theme.colors`, `theme.boxShadow`, etc. to consume those variables, so Tailwind utilities become token-aware.
+- **`.article-body`** is a layered CSS class that wraps rendered markdown — keeps prose-specific overrides out of inline classes.
+- **No CSS Modules, no styled-components.** Tailwind + the design tokens is sufficient.
+
+## Image handling
+
+- Always through `OptimizedImage` (a thin wrapper around `next/image`).
+- Remote domains explicitly whitelisted in `next.config.mjs → images.remotePatterns`. Adding a new CDN means a config change + redeploy.
+- Output formats: WebP and AVIF, with multiple device sizes generated at build.
+
+## Monetization integration
+
+**AdSense** is a build-time-configurable, runtime-rendered concern.
+
+- `lib/adsense-config.ts` holds all slot IDs and a `shouldShowAds()` gate.
+- `components/ads/AdBanner.tsx` renders either a labeled placeholder (dev) or the real AdSense script (prod with publisher ID set).
+- The publisher ID comes from `NEXT_PUBLIC_ADSENSE_PUBLISHER_ID`. If missing in a production build, the build logs a **warning** (not an error — see commit `89e8987`) so CI passes on forks without secrets.
+
+**Affiliate links** are pure markup. `retailerLinks` in frontmatter → `RetailerLinks` / `PriceButton` components → `<a rel="noopener noreferrer nofollow">`. Every URL passes `isSafeUrl()` first.
+
+## Security posture
+
+From `next.config.mjs` and observed practice:
+
+- **Content-Security-Policy** header. `script-src` allows `'unsafe-inline'` because AdSense's `adsbygoogle.js` needs it.
+- Allow-listed external script origins: Google Analytics, Google Tag Manager, Google AdSense.
+- `X-Frame-Options`, `Referrer-Policy`, and friends set conservatively.
+- **No raw HTML in markdown** — body is sanitized by the custom `marked` renderer.
+- **URL validation** at render time via `isSafeUrl()` — prevents `javascript:` and similar.
+
+## Build & deploy pipeline
+
+`.github/workflows/nextjs.yml`:
+
+1. Trigger: push to `main` (or manual dispatch).
+2. Checkout, detect package manager, set up Node 20.
+3. Configure GitHub Pages (static export target).
+4. Restore `.next/cache/`.
+5. `npm ci`.
+6. `npx next build` — produces `./out/`.
+7. Upload `./out/` as artifact.
+8. Deploy to GitHub Pages.
+
+Typical pipeline duration: 2–3 minutes.
+
+## Performance targets
+
+From `PRODUCTION.md`:
+
+- **LCP** < 2.5s
+- **FID** < 100ms
+- **CLS** < 0.1
+- **Lighthouse:** Performance > 90, Accessibility > 95, Best Practices > 90, SEO > 95
+
+Levers we have:
+
+- Static HTML (zero server time-to-first-byte).
+- AVIF/WebP via `next/image`.
+- Tailwind purging keeps CSS small.
+- RSC keeps the JS bundle to interactive islands only.
+- Pre-declared image dimensions on every `OptimizedImage` keeps CLS near zero.
+
+## Known constraints & trade-offs
+
+| Constraint | Consequence | Mitigation |
+|---|---|---|
+| Static-only hosting (Pages) | No personalization, no A/B testing without client JS | Run experiments via client-side scripts or move to Vercel |
+| Markdown source-of-truth | No editorial CMS UI | Frontmatter is human-friendly; a CMS could be layered on top later |
+| AdSense `'unsafe-inline'` | CSP is weaker than ideal | Acceptable for the revenue trade-off; revisit if AdSense supports nonces |
+| `marked` (not MDX) | No React components inside content | Conscious choice — keeps content authorable by non-devs |
+| No automated tests | Regressions caught only at `npm run test:build` | Coverage is a known gap (PRD calls for 80%); add when stable |
+
+## Where to go next
+
+- **Route map:** [reference/routes.md](./reference/routes.md)
+- **Components:** [reference/components.md](./reference/components.md)
+- **Content schema:** [reference/content-schema.md](./reference/content-schema.md)

--- a/docs/for-content-editors.md
+++ b/docs/for-content-editors.md
@@ -1,0 +1,189 @@
+# For Content Editors
+
+How to write, structure, and publish a review on ProductLabR. No code required — just markdown, a text editor, and good editorial judgment.
+
+## The shape of a review
+
+Every review is a single markdown file at:
+
+```
+posts/<category>/<slug>.md
+```
+
+- `<category>` is the directory: `portable-power-stations`, `cameras`, `laptops`, etc.
+- `<slug>` is the URL-safe filename: lowercase, words separated by underscores or hyphens. Example: `ecoflow_delta_3_plus.md` → `/articles/ecoflow_delta_3_plus`.
+
+The file has **two parts**:
+
+1. **Frontmatter** — YAML between two `---` lines. Structured metadata.
+2. **Body** — Markdown prose underneath. The review itself.
+
+## Minimum-viable frontmatter
+
+```yaml
+---
+title: "EcoFlow Delta 3 Plus"
+subtitle: "A 1 kWh powerhouse with the fastest recharge in its class"
+date: "2026-04-10"
+author: "Jane Doe"
+price: "$999"
+productImage: "https://example.com/path/to/image.jpg"
+specs:
+  Capacity: "1024 Wh"
+  AC Output: "1800 W"
+  Solar Input: "500 W"
+  Weight: "27 lbs"
+pros:
+  - "Sub-1-hour AC recharge"
+  - "X-Boost handles 1800 W appliances"
+  - "Quiet under 500 W load"
+cons:
+  - "App is iOS-only at launch"
+  - "Heavy for its category"
+retailerLinks:
+  Amazon: "https://www.amazon.com/dp/XXXX?tag=YOURTAG"
+  BestBuy: "https://www.bestbuy.com/site/..."
+ratingBreakdown:
+  metrics:
+    - { name: "Performance", score: 9.2 }
+    - { name: "Design & Build", score: 8.5 }
+    - { name: "Value", score: 8.0 }
+    - { name: "App & Features", score: 7.5 }
+---
+```
+
+**Full schema with every optional field:** [reference/content-schema.md](./reference/content-schema.md).
+
+## Category-specific extras
+
+Some categories require extra frontmatter so the review can appear on filtered sub-category pages. For **power stations**:
+
+```yaml
+capacityWh: 1024            # number, no units
+features:                   # any subset of these tags
+  - "30a-rv"
+  - "solar"
+  - "solar-kit"
+  - "240v"
+  - "cpap"
+  - "van-life"
+```
+
+If you skip these, the review won't surface on the new sub-category pages (RV, solar, CPAP, van-life, etc.). Detail by feature:
+
+| Tag | When to apply it |
+|---|---|
+| `30a-rv` | Has a TT-30 (30A) RV outlet |
+| `solar` | Solar input ≥ 200W |
+| `solar-kit` | Sold/bundled with a panel |
+| `240v` | True 240V output (not just 120V split-phase trick) |
+| `cpap` | 500–1500 Wh, < 25 lbs, quiet — a viable CPAP companion |
+| `van-life` | < 30 lbs and ≥ 400W solar input |
+
+## How rankings work
+
+The overall score shown on the article and used for ranking on category pages is the **average of `ratingBreakdown.metrics[].score`**. There's no separate "overall score" field — keep the metrics honest and the average will be right.
+
+Common metric names (consistency helps readers compare across reviews):
+
+- **Performance** — does it do the job?
+- **Design & Build** — quality, fit, finish, ergonomics
+- **Value** — for the price
+- **App & Features** — software, connectivity
+- **Battery / Runtime** — where relevant
+- **Sound / Image / Display** — category-specific
+
+Use the same metric names across reviews in the same category whenever possible.
+
+## Writing the body
+
+The body is rendered through a custom markdown pipeline (`lib/markdown.ts`) that styles standard markdown into the article look. **Stick to standard markdown.** Inline HTML is stripped for security.
+
+Supported:
+
+- `# H1` (rare — the title comes from frontmatter)
+- `## H2` — becomes an anchored, underlined section heading. These appear in the Table of Contents.
+- `### H3` — sub-headings
+- **Bold**, *italic*, `inline code`
+- Bulleted and numbered lists
+- > Blockquotes — render with a light-blue surface and a primary-blue left border
+- Code blocks (rarely needed)
+- Links — `[text](https://...)` — always full URLs
+- Images — `![alt](url)` — see image rules below
+
+### Suggested structure
+
+A consistently structured review reads better and ranks better.
+
+```
+## Verdict (1 paragraph)
+## Who it's for (bullets or short prose)
+## Design & build
+## Performance
+## In real-world use
+## Value & alternatives
+## The bottom line
+```
+
+Keep paragraphs short — 2–4 sentences. The body type is 15px / 1.8, optimized for scanability on mobile.
+
+## Image rules
+
+- Use full https URLs. Allowed domains today: Amazon S3 (`*.s3.amazonaws.com`), Bob Vila CDN, Future CDN. New domains need engineering to whitelist.
+- Always provide **descriptive alt text** — it's an accessibility requirement and an SEO signal.
+- **Hero / product image** goes in frontmatter (`productImage`), not the body.
+- Body images should be photos that *add* something (in-use shots, comparison shots). Don't pad.
+
+## Affiliate links
+
+- Every retailer link goes in `retailerLinks` — not in the body. The article auto-renders buy buttons from this map.
+- The site adds `rel="noopener noreferrer nofollow"` and validates URLs through a safety check. `javascript:` URLs are rejected.
+- Use **canonical product URLs** with your affiliate tag appended. Avoid shorteners — they look spammy and break occasionally.
+
+## Slug & filename rules
+
+- Lowercase only.
+- Words separated by `_` or `-`.
+- Must match the regex `/^[a-z0-9]+(?:[_-][a-z0-9]+)*$/i` — no spaces, no special characters.
+- The filename **is** the URL slug (`my_product.md` → `/articles/my_product`). Don't rename after publishing — you'll break inbound links.
+
+## Publishing a review
+
+1. Create the file under the right `posts/<category>/` directory.
+2. Fill in **all required frontmatter** (title, date, price, productImage, specs, pros, cons, retailerLinks, ratingBreakdown).
+3. Write the body.
+4. Commit on a feature branch (`nmehrok/addReviewEcoflowDelta3Plus`).
+5. Open a draft PR. Engineering will build and preview.
+6. Once merged to `main`, GitHub Actions builds and deploys to GitHub Pages within ~2–3 minutes.
+
+If you don't have engineering access, hand the markdown file to an engineer and they'll commit it.
+
+## Quality checklist before you hit publish
+
+- [ ] Title is the product name, no editorializing
+- [ ] `date` is today's date in `YYYY-MM-DD` format
+- [ ] Subtitle gives a one-sentence hook
+- [ ] `productImage` resolves (open it in a browser)
+- [ ] At least 3 specs, 2 pros, 2 cons
+- [ ] At least one retailer link, tested in a private/incognito tab
+- [ ] All `ratingBreakdown.metrics` filled in with thoughtful scores
+- [ ] H2 headings used (so the Table of Contents has anchors)
+- [ ] No raw HTML in the body
+- [ ] No internal-only notes accidentally left in the body
+- [ ] Category-specific frontmatter present (e.g. `capacityWh`, `features` for power stations)
+
+## Common mistakes
+
+| Mistake | Why it matters |
+|---|---|
+| Putting buy links in the body | The article's buy buttons are auto-generated from frontmatter; body links bypass affiliate styling |
+| Score fields outside 0–10 | The star derivation and average break |
+| Using emojis in titles | We don't put emojis in the product itself; reserve them for the finder quiz UI |
+| Spaces in slugs / filenames | Build fails; URL becomes ugly |
+| Missing `productImage` | Card layouts fall back to a placeholder — looks unprofessional |
+| Reusing scores across many reviews | Readers calibrate quickly; 9s lose meaning if everything's a 9 |
+
+## Where to go next
+
+- **Full frontmatter reference:** [reference/content-schema.md](./reference/content-schema.md)
+- **How the rendered prose is styled (so you know what your H2s will look like):** [for-designers.md](./for-designers.md#typography)

--- a/docs/for-designers.md
+++ b/docs/for-designers.md
@@ -1,0 +1,147 @@
+# For Designers
+
+The visual and interaction system behind ProductLabR — tokens, type, components, and motion — written so you can design *with* the system, not against it.
+
+## Design language
+
+Editorial, magazine-inspired, restrained. Reference points: TechRadar, Wirecutter, The Verge — confident typography, generous whitespace, a single accent color used sparingly, and product photography that's allowed to breathe.
+
+## Color tokens
+
+Defined in `styles/theme.css` as HSL CSS variables. Use them through Tailwind utilities (e.g. `bg-primary`, `text-neutral-700`), never as hex literals in components.
+
+| Token | Value | Use |
+|---|---|---|
+| `--primary` | `hsl(204 100% 40%)` ≈ `#007ACC` | Links, primary buttons, score highlights |
+| `--primary-dark` | `#005C99` | Primary hover/pressed |
+| `--primary-darker` | `#003D66` | Primary active / focused background |
+| `--primary-light` | `#B3D9FF` | Subtle highlights, table emphasis |
+| `--primary-lightest` | `#E6F2FF` | Hero gradients, callout backgrounds |
+| `--accent` | `hsl(24 79% 56%)` ≈ `#E87B35` | Award badges, single-point emphasis |
+| `--neutral-50 → 900` | warm grays | Body text, borders, surfaces |
+| `--success` / `--error` | semantic | Pros/cons, validation states |
+
+**Rule of thumb:** the accent orange is the loudest color in the system. Limit it to one element per viewport (typically an award badge or a CTA). Everything else lives in primary blue + neutral grays.
+
+## Typography
+
+Two families, both Google Fonts with `display: swap`.
+
+| Family | Role | Typical sizes |
+|---|---|---|
+| **Playfair Display** (`--font-display`) | Editorial headings (article titles, hero headlines, section H2s) | 28–56px |
+| **Inter** (`--font-sans`) | Body, UI, metadata, captions | 13–17px |
+
+**Article-body type** (`.article-body` in `styles/global.css`):
+
+- Body: **15px / 1.8** line height
+- H2: **20px** semibold, **2px blue underline**, anchor-linkable, `scroll-margin-top: 5rem` so deep-links don't hide under the sticky header
+- H3: **17px** semibold
+- Links: primary blue with underline offset (no hover color shift — only weight)
+- Code: light gray surface, monospace
+- Blockquote: light blue surface, left border in primary
+
+When designing new content components, **match `.article-body` rhythm** so they sit naturally inside reviews.
+
+## Spacing & layout
+
+- Tailwind's default spacing scale (4px base). Stick to it — don't introduce arbitrary `mt-[13px]`.
+- **Max content width:** `--max-width: 1280px`. The home and best hubs use `lg:grid-cols-[7fr_3fr]` (content / sidebar).
+- **Article columns:** narrower body (~720px) for readability; sidebars hug the right rail on `lg+`.
+- **Section rhythm:** vertical gaps usually `gap-8` (32px) on desktop, `gap-6` (24px) on mobile.
+
+## Radii, shadows, borders
+
+- `--radius: 0.5rem` (8px) → Tailwind `rounded-md`. `rounded-lg` and `rounded-sm` derive from it.
+- `shadow.card-hover` and `shadow.featured` are defined in `tailwind.config.ts` — use these instead of inventing custom shadows.
+- Borders are usually `border-neutral-200` at rest, `border-primary-light` on hover/active.
+
+## Component anatomy
+
+The components below are the visual building blocks. Full props in [reference/components.md](./reference/components.md); design-relevant anatomy here.
+
+### `RankedProductCard`
+
+The workhorse of category pages.
+
+```
+┌──────────────────────────────────────────────┐
+│  #1   [Award Badge — orange or blue]         │  ← rank chip top-left
+│ ┌──────────┐                                 │
+│ │          │   Product Name (Playfair, 20px) │
+│ │  image   │   1-line summary (Inter, 14px)  │
+│ │          │   Score 9.2 · $1,099            │
+│ └──────────┘                                 │
+│                  [Buy Now →]   (stretched)   │
+└──────────────────────────────────────────────┘
+```
+
+- **Whole card is clickable** (stretched link). The Buy button morphs on hover.
+- **Lift + shadow on hover** — see commits `48b962d`, `11a141b`. Subtle: 2–4px translate, slight shadow bloom. Don't exaggerate.
+- Badge color: `best-overall` uses accent orange; `best-value` and `budget-pick` use blue variants.
+
+### `ScoreCard` / `ScoreBadge`
+
+- Big circular badge with the 0–10 score.
+- Color ramp: ≥9 = primary, 7–8.9 = primary-light, <7 = neutral.
+- Pairs with `StarRating` (0–5 derived) for at-a-glance comprehension.
+
+### `ComparisonCard`
+
+Side-by-side, two-column grid. Winning rows (e.g. higher capacity) get a **primary-light background tint** — never a heavy fill. Verdict box sits below the spec table.
+
+### `PowerStationQuiz`
+
+Three sequential questions with emoji icons. Submit is disabled until all three are answered. On submit, routes to one of the seven sub-category pages via a deterministic matrix in `getRoute()`.
+
+Design rules:
+- Keep options visually balanced — no option should feel like the obvious "right answer."
+- Icons are decorative; never the only signifier (label is always present).
+- Final CTA uses primary fill, not accent.
+
+### `Newsletter`
+
+Single input + button. Inline validation only; never a modal.
+
+### `AdBanner`
+
+In dev, shows a **labeled gray placeholder** at the configured size. In prod, the real AdSense unit. Design around the *placeholder* dimensions so layouts don't shift when ads load (CLS budget is tight — target < 0.1).
+
+## Motion
+
+Framer Motion is installed but used **sparingly**. The aesthetic is editorial, not playful.
+
+- **Card hover:** transform + shadow, 150–200ms, ease-out.
+- **Page transitions:** none. Static export + GitHub Pages = no SPA transitions.
+- **Quiz step transitions:** fade + slight slide if added; keep under 250ms.
+- **Reduced motion:** respect `prefers-reduced-motion`. Any new motion needs a `@media (prefers-reduced-motion: reduce)` fallback.
+
+## Imagery
+
+- **Product shots on white/transparent** preferred. Lifestyle imagery only for hero blocks.
+- All images go through `OptimizedImage` → Next.js Image → WebP/AVIF. Provide an explicit width/height to prevent CLS.
+- **Remote domains** are whitelisted (S3, Bob Vila, Future CDN). New domains require a code change.
+- **Hero images** typically 16:9 or 3:2. Cards use 4:3.
+
+## Accessibility
+
+This is a hard requirement, not aspirational. The site targets **Lighthouse Accessibility > 95**.
+
+- **Color contrast:** body text on white must clear 4.5:1. Primary blue on white passes; light blues don't — never use `--primary-lightest` for text.
+- **Focus rings:** visible. Don't suppress the default outline unless you replace it with an equally visible one.
+- **Semantic HTML:** headings in order; lists are `<ul>`/`<ol>`; buttons are `<button>` not styled `<div>`s.
+- **Alt text:** every product image needs descriptive alt; decorative icons use `aria-hidden`.
+- **Tap targets:** ≥44×44px on mobile.
+
+## How to propose a design change
+
+1. Sketch in Figma against the **token list above** — if your design needs a new token, that's a system-level decision, call it out.
+2. Reference existing components by name when handing off. If the change extends an existing component (new variant), add it via `class-variance-authority` rather than forking the component.
+3. Note any motion timings and reduced-motion fallbacks in the spec.
+4. For new content patterns, propose them as a markdown-renderable construct first — if it can't be expressed in markdown + frontmatter, the editorial workflow gets harder.
+
+## Where to go next
+
+- **Component catalog (props):** [reference/components.md](./reference/components.md)
+- **Live tokens:** `styles/theme.css`, `tailwind.config.ts`
+- **PM context (why these patterns exist):** [for-product-managers.md](./for-product-managers.md)

--- a/docs/for-developers.md
+++ b/docs/for-developers.md
@@ -1,0 +1,216 @@
+# For Developers
+
+Everything you need to be productive in this repo: setup, mental model, conventions, and where the bodies are buried.
+
+## Quick start
+
+```bash
+# Install
+npm ci
+
+# Develop (localhost:3000, fast refresh)
+npm run dev
+
+# Validate before pushing
+npm run test:build      # lint + type-check + production build
+
+# Format & lint
+npm run lint:fix
+npm run format
+```
+
+Copy `.env.example` → `.env.local` for AdSense / GA env vars (placeholders are fine for local dev).
+
+## Mental model
+
+The site is a **content-driven, statically-rendered Next.js App Router app**.
+
+```
+posts/*.md  ──►  lib/Posts.ts  ──►  app/**/page.tsx (RSC)  ──►  static HTML  ──►  GitHub Pages
+                        ▲
+                        │
+                  React.cache() so a single
+                  build pass reads each file once
+```
+
+No database. No runtime API. The build is the database.
+
+## Repo tour
+
+```
+app/                    Next.js App Router routes
+├── layout.tsx          Root layout (fonts, header/footer, GA, AdSense bootstrap)
+├── page.tsx            Home
+├── articles/[slug]/    Individual reviews (SSG, generateStaticParams)
+├── best/               Category hub + verticals + sub-categories + compare pages
+├── sitemap.ts          Auto-generated sitemap
+└── robots.ts           Auto-generated robots.txt
+
+components/             ~30 components (see reference/components.md for the catalog)
+├── article/            Article-specific (specs, pros/cons, score card, etc.)
+└── ads/                AdBanner, ResponsiveAd
+
+lib/                    Pure helpers, no React
+├── Posts.ts            getPostBySlug, getAllPostSlugs, getPostsByCategory
+├── power-station-data.ts  Typed filters for the power-stations vertical
+├── markdown.ts         marked + Tailwind class injection
+├── articleUtils.ts     calculateOverallScore, scoreToStarRating, formatArticleDate
+├── adsense-config.ts   Ad slot IDs + shouldShowAds() gate
+├── utils.ts            cn(), isSafeUrl()
+└── icons.tsx           Feature-flag icons (solar, RV, CPAP, ...)
+
+posts/                  Markdown content — the source of truth
+└── <category>/<slug>.md
+
+styles/                 global.css + theme.css (CSS variables)
+public/                 Static assets
+scripts/                Build/research utilities
+```
+
+## Routing conventions
+
+- Routes are defined by **folder structure** under `app/` (App Router).
+- **Dynamic segments** use `[param]` folders. Article routes pre-render at build time via `generateStaticParams()`.
+- **Static export** means *every* dynamic route must enumerate its params at build time. There is no runtime fallback.
+- For pages that the harness might try to render dynamically, we pin them with `export const dynamic = 'force-static'` (see `sitemap.ts`, `robots.ts`).
+- Per-article revalidation: `export const revalidate = 86400` (24h). This is moot on Pages but kept for forward-compat with Vercel.
+
+See [reference/routes.md](./reference/routes.md) for the complete route map.
+
+## Data layer
+
+Read [`lib/Posts.ts`](../lib/Posts.ts) first. The contract:
+
+```ts
+getPostBySlug(slug)       // → { metadata, content }
+getAllPostSlugs()         // → string[]   (for generateStaticParams)
+getPostsByCategory(cat)   // → Post[]     (sorted newest first)
+getCategoryDisplayName(slug) // → "Portable Power Stations"
+```
+
+All readers are wrapped in `React.cache()`. Within a single build pass, a file is parsed once even if 10 pages request it.
+
+For typed vertical-specific filtering, see `lib/power-station-data.ts` — this is the **pattern to copy** for new verticals. It exposes:
+
+```ts
+getAllPowerStations()                // PowerStationEntry[]
+getStationsByFeature("30a-rv")
+getStationsUnderPrice(500)
+getStationsBySlugs(["ecoflow-delta-3-plus", "anker-solix-c1000"])
+getQuickPicks(entries)               // { bestOverall, bestValue, budgetPick }
+```
+
+## Content & frontmatter
+
+Every review is a markdown file with YAML frontmatter. Full schema lives at [reference/content-schema.md](./reference/content-schema.md). The minimum-viable shape:
+
+```yaml
+---
+title: "EcoFlow Delta 3 Plus"
+date: "2026-04-10"
+price: "$999"
+productImage: "https://..."
+specs:
+  Capacity: "1024 Wh"
+  AC Output: "1800 W"
+pros: ["Fast charging", "App control"]
+cons: ["Heavy"]
+retailerLinks:
+  Amazon: "https://www.amazon.com/..."
+ratingBreakdown:
+  metrics:
+    - { name: "Performance", score: 9 }
+    - { name: "Value", score: 8 }
+---
+
+Body markdown here.
+```
+
+Markdown is rendered through `lib/markdown.ts` which:
+1. Runs `marked` with GFM + line breaks.
+2. Strips inline HTML (XSS hardening).
+3. Regex-injects Tailwind classes onto headings/links/code/etc.
+
+If you find yourself wanting MDX, push back — `marked` keeps content authorable by non-developers.
+
+## Styling
+
+- **Tailwind CSS 3.4**, configured in `tailwind.config.ts`. Content paths cover `app/` and `components/`.
+- **Design tokens** live as CSS variables in `styles/theme.css` (consumed via Tailwind's `theme.extend`). Don't hardcode colors — reach for `--primary`, `--accent`, `--neutral-*`.
+- **Two fonts**: `--font-sans: Inter` (body), `--font-display: Playfair Display` (headings).
+- **Article body** has bespoke prose styling in `.article-body` (see `styles/global.css`). Use it on any rendered-markdown container.
+
+Designers' deeper take: [for-designers.md](./for-designers.md).
+
+## Conventions
+
+From `copilot-instructions.md` and observed practice:
+
+- **TypeScript strict.** Prefer `interface` over `type`. No `enum` — use string literal unions.
+- **Default to RSC.** Add `'use client'` only when a component needs state/effects/event handlers (e.g. `PowerStationQuiz`, `SearchBar`).
+- **No `useEffect` for data.** Fetch in server components; pass props down.
+- **Images:** always `OptimizedImage` (wraps `next/image`). Don't inline `<img>`.
+- **External URLs:** always run through `isSafeUrl()` in `lib/utils.ts` before rendering an href.
+- **Class merging:** use `cn()` (clsx + tailwind-merge).
+- **Component variants:** use `class-variance-authority` when you have ≥3 visual variants.
+- **No emojis in code or comments** unless the user asks for them.
+- **Comments** are for non-obvious *why*, not *what*. Skip them otherwise.
+
+## Build, deploy, and CI
+
+- **Build:** `npm run build` produces a static export in `./out/`.
+- **CI:** `.github/workflows/nextjs.yml` runs on push to `main`. Steps: install → build → upload `./out/` → deploy to Pages.
+- **No tests in CI yet.** `npm run test:build` is the closest thing to a test gate (lint + type-check + build). Coverage is a known gap.
+- **Bundle analysis:** `npm run build:analyze` (sets `ANALYZE=true`).
+- **Preview prod locally:** `npm run preview` (build + start).
+
+Full deploy notes: [`PRODUCTION.md`](../PRODUCTION.md).
+
+## Working with ads
+
+- All ad placement goes through `<AdBanner adSlot="..." adFormat="..." />`.
+- Slots are typed via `ADSENSE_CONFIG` in `lib/adsense-config.ts`. Add a new slot there before referencing it.
+- `shouldShowAds()` gates rendering: dev shows a labeled placeholder; prod shows real ads only when `NEXT_PUBLIC_ADSENSE_PUBLISHER_ID` is set to a real `ca-pub-...` value.
+- The build emits a **warning** (not an error) if the env var is missing — see commit `89e8987`. Don't tighten this back to an error or CI will fail on forks.
+
+## Local-dev gotchas
+
+| Symptom | Cause / Fix |
+|---|---|
+| New image domain 403s | Add it to `images.remotePatterns` in `next.config.mjs` |
+| Static export complains about a dynamic route | Add `generateStaticParams()`, or set `export const dynamic = 'force-static'` |
+| AdSense placeholder shows in prod | Env var `NEXT_PUBLIC_ADSENSE_PUBLISHER_ID` not set in the deploy environment |
+| Stale build output | Delete `.next/` and `out/`, rebuild |
+| Slug not found at runtime | The slug isn't in `posts/<category>/`, or has invalid characters (must match `/^[a-z0-9]+(?:[_-][a-z0-9]+)*$/i`) |
+
+## Branching & PR conventions (user preference)
+
+From `~/.claude/rules/preferences.md`:
+
+- Branch names: `nmehrok/<camelCaseDescription>`, e.g. `nmehrok/addPowerStationQuiz`.
+- PRs created in **draft mode** (`gh pr create --draft`).
+- PR body must have **Summary** (1–2 sentence prose), **Details** (bullets grouped by area), **Testing Done** (checkboxes).
+- Don't auto-push after fixing review issues — wait for approval.
+
+## Adding a new sub-category page (worked example)
+
+The power-station expansion is the reference implementation. To add a new one:
+
+1. Ensure source data has the filter field (e.g. add `features: ["my-tag"]` to relevant reviews).
+2. Add a filter to `lib/power-station-data.ts` (or its equivalent for your vertical).
+3. Copy an existing page directory under `app/best/power-stations/` and adapt:
+   - Hero (title, description, tag pills, gradient class).
+   - `<QuickPicks />` fed by `getQuickPicks(filtered)`.
+   - Ranked list mapping `filtered.map(...)` to `<RankedProductCard />`.
+   - Unique buying-guide prose.
+   - Sidebar with at least one cross-link.
+4. Link the new page from the parent hub's category grid.
+5. Add it to the relevant finder-quiz routing matrix (`PowerStationQuiz.getRoute`).
+6. Run `npm run test:build` and verify the route in the build output.
+
+## Where to go next
+
+- **Architecture deep dive:** [architecture.md](./architecture.md)
+- **Component catalog with props:** [reference/components.md](./reference/components.md)
+- **Route map:** [reference/routes.md](./reference/routes.md)
+- **Production checklist:** [`PRODUCTION.md`](../PRODUCTION.md)

--- a/docs/for-product-managers.md
+++ b/docs/for-product-managers.md
@@ -1,0 +1,142 @@
+# For Product Managers
+
+This guide gives you the **mental model** of ProductLabR you need to plan features, prioritize content, and reason about monetization — without getting into code.
+
+## The product in one sentence
+
+ProductLabR helps shoppers decide *which* product to buy in a specific category, then earns revenue when they click out to retailers or view ads on the way.
+
+## Audience & jobs to be done
+
+| Visitor intent | Entry surface | What we need to deliver |
+|---|---|---|
+| "Which X is best for me?" | `/best/<category>` hub or finder quiz | Ranked list with clear winners by use-case |
+| "Is product Y worth it?" | `/articles/<slug>` (review) | Score, pros/cons, specs, buy buttons |
+| "X vs Y — which one?" | `/best/.../compare/<a>-vs-<b>` | Side-by-side specs, verdict |
+| "What's new?" | `/` (home) | Latest reviews, editor's pick |
+
+## Information architecture
+
+```
+Home (/)
+├── Latest reviews
+├── Editor's pick (hero)
+├── Best Of guides (curated 4)
+└── Sidebar: Top 10 Popular · Newsletter · Categories
+
+Best (/best)
+├── Featured categories
+├── How We Test (methodology)
+└── Browse all categories
+
+Best > Vertical (e.g. /best/power-stations)
+├── Hero
+├── Finder quiz (optional, vertical-specific)
+├── Sub-category grid
+└── Sidebar: jump-links · guides · compare shortcuts
+
+Best > Vertical > Sub-category (e.g. /best/power-stations/rv-power-stations)
+├── Breadcrumb
+├── Hero with tag pills
+├── Quick Picks (top 3)
+├── Ranked list (RankedProductCard)
+├── Buying guide prose
+└── Sidebar
+
+Article (/articles/<slug>)
+├── Hero image + score card
+├── Specs · Pros/Cons · Ratings breakdown
+├── Body (markdown)
+├── Sticky buy bar
+└── Related articles
+```
+
+## Content inventory (today)
+
+| Category | Reviews | Notes |
+|---|---:|---|
+| Portable power stations | 33 | The largest vertical; active expansion |
+| Cameras | 15 | Hybrid, pro photo, pro generic sub-hubs |
+| Laptops | 9 | Under-$1k, gaming, MacBooks |
+| Headphones | 8 | Noise-cancelling, wireless earbuds |
+| Gaming | 8 | Keyboards, mice |
+| Monitors | 8 | 4K, gaming |
+| Smart home | 8 | Robot vacuums, smart speakers |
+| TVs | 7 | Gaming TVs, OLED |
+| Wearables | 4 | Smartwatches |
+| Knives & tools | 1 | Seed |
+| **Total** | **101** | |
+
+## How a review is ranked
+
+Each review's frontmatter contains a `ratingBreakdown.metrics[]` array — named criteria scored 0–10 (e.g. "Design & Build," "Performance," "Value"). The overall score is the **average** of those metrics (`lib/articleUtils.ts → calculateOverallScore`). Star ratings are derived 0–5 from the 0–10 score.
+
+Position on a category page is determined by score; the top three on a sub-category page are surfaced as **Quick Picks** with award badges:
+
+- 🥇 `best-overall` — top score
+- 💸 `best-value` — best score-per-dollar
+- 🪙 `budget-pick` — lowest price among acceptable scores
+
+## Monetization model
+
+**Ads** (display, Google AdSense)
+
+| Slot | Where it appears |
+|---|---|
+| `articleTop`, `articleMid`, `articleBottom` | Inside reviews |
+| `sidebar` | Home + category sidebars |
+| `homeHeaderMobile`, `homeHeaderDesktop` | Above the fold on home |
+| `homeBetweenCategories` | Between home sections |
+| `categoryTop`, `categoryBottom` | Top/bottom of category hubs |
+
+Revenue scales with traffic × CPM × ad density. AdSense policies cap density and quality — we don't auto-stack ads.
+
+**Affiliate links** (per-retailer, in frontmatter)
+
+Every review can list multiple `retailerLinks` (Amazon, Best Buy, B&H, etc.). The article's buy button and the sticky buy bar deep-link to these. Conversion attribution is handled by the retailer's affiliate program.
+
+**Revenue expectations** (from `ADSENSE_SETUP.md`)
+- Month 1: $0–$50 (during AdSense approval)
+- Month 3: $50–$200
+- Month 6+: $200+
+
+## What constitutes "shipped" for a new category
+
+To launch a new sub-category page, the bar is:
+
+1. **≥5 reviews** with complete frontmatter for that filter (price, score, relevant features).
+2. **Quick Picks** identifiable — at least one of each badge type.
+3. **Buying guide prose** unique to the sub-category (not boilerplate).
+4. **Sidebar** with jump-links and at least one cross-link (compare page, related guide).
+5. **Internal links** from the parent hub and at least one comparison page.
+
+## Success metrics to watch
+
+- **Organic sessions / category** (Search Console). Category pages should outrank individual reviews for "best X" queries.
+- **Article → outbound retailer CTR** — the primary conversion event.
+- **Quiz completion rate** on hubs that have a finder.
+- **Compare page traffic** vs. individual review traffic — confirms head-to-head intent.
+- **Core Web Vitals** — LCP < 2.5s, CLS < 0.1, FID < 100ms. Performance directly affects SEO rank.
+- **Lighthouse**: target SEO > 95, Performance > 90, Accessibility > 95.
+
+## Constraints you should know about
+
+- **Static export** — there is no server at runtime. Anything personalized, A/B tested, or user-specific has to run **client-side** (e.g. the finder quiz uses `'use client'`). This rules out per-user SSR.
+- **GitHub Pages hosting** — no edge functions, no ISR. Content updates require a redeploy (≈2–3 min on push to `main`).
+- **AdSense approval gate** — placeholders show in dev. Real ads require an approved publisher ID set via env var.
+- **Image domains are whitelisted** in `next.config.mjs`. New CDNs require a config change + redeploy.
+
+## How to request a new vertical
+
+Use the existing power-station expansion as the template:
+
+1. Write a **design spec** under `docs/superpowers/specs/` — IA, page anatomy, filter logic.
+2. Write a **plan** under `docs/superpowers/plans/` — task list, file paths, acceptance criteria.
+3. Ensure content exists or has a path to existence (≥5 reviews).
+4. Hand off to engineering. They'll mirror the `power-stations/` pattern.
+
+## Where to go next
+
+- **Architecture deep dive:** [architecture.md](./architecture.md)
+- **Route map:** [reference/routes.md](./reference/routes.md)
+- **Content schema (what each frontmatter field means):** [reference/content-schema.md](./reference/content-schema.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,73 @@
+# ProductLabR — Overview
+
+ProductLabR is an **editorial product-review site**: long-form, ranked, "best of" buying guides for consumer electronics and outdoor gear. It is content-driven (every review is a markdown file), statically rendered, and monetized through display ads and affiliate links.
+
+## In one diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  CONTENT                                                        │
+│  posts/<category>/<slug>.md   — YAML frontmatter + markdown     │
+│                          │                                      │
+│                          ▼                                      │
+│  DATA LAYER          lib/Posts.ts, lib/power-station-data.ts    │
+│  (cached readers, filters, slug helpers)                        │
+│                          │                                      │
+│                          ▼                                      │
+│  ROUTES (Next.js App Router)                                    │
+│  /                  → home (latest, best-of, sidebar)           │
+│  /articles/[slug]   → single review (SSG, generateStaticParams) │
+│  /best              → category hub                              │
+│  /best/<vertical>/<sub>  → ranked list pages                    │
+│  /best/.../compare/<a>-vs-<b>  → head-to-head                   │
+│                          │                                      │
+│                          ▼                                      │
+│  RENDER  React Server Components → static HTML (export to /out) │
+│                          │                                      │
+│                          ▼                                      │
+│  DEPLOY  GitHub Actions → GitHub Pages (static hosting)         │
+│                                                                 │
+│  MONETIZE  Google AdSense slots + affiliate retailer links      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## What's on the site
+
+- **101 reviews** across 10 categories — the largest is **portable power stations** (33 reviews).
+- **Category hubs** under `/best/` with ranked lists, "quick picks," and buying guides.
+- **Comparison pages** for head-to-head matchups (initially power stations).
+- **Interactive finder quizzes** (e.g. `PowerStationQuiz`) that route users to the right category page.
+
+## How it makes money
+
+1. **Display ads** — Google AdSense slots placed in article tops/mids/bottoms, sidebars, and between home sections. Configured in `lib/adsense-config.ts`. Dev shows placeholders; prod shows real ads once the publisher ID env var is set.
+2. **Affiliate links** — Each review's frontmatter has a `retailerLinks` map (Amazon, Best Buy, etc.). All outbound links use `rel="noopener noreferrer nofollow"` and are validated by `isSafeUrl()` before render.
+
+## Tech stack at a glance
+
+| Layer | Choice |
+|---|---|
+| Framework | Next.js 16 (App Router) + React 19 + TypeScript 5 strict |
+| Styling | Tailwind CSS 3.4 + CSS variables + Playfair Display / Inter |
+| Content | Markdown (`marked`) + YAML frontmatter (`gray-matter`) |
+| Motion | Framer Motion (used sparingly — see designer guide) |
+| Analytics | `@next/third-parties` (Google Analytics, AdSense) |
+| Hosting | GitHub Pages (static export) |
+| CI | GitHub Actions (`.github/workflows/nextjs.yml`) |
+
+## Roadmap (active)
+
+The current in-flight effort is the **power station category expansion** (see [spec](./superpowers/specs/2025-05-06-power-station-categories-design.md) and [plan](./superpowers/plans/2025-05-06-power-station-category-expansion.md)):
+
+- Add `capacityWh` and `features` frontmatter to the 33 power-station reviews.
+- Ship 7 new sub-category pages (RV, solar, under-$500, under-$1000, CPAP, 240V, van-life).
+- Ship 3 head-to-head comparison pages.
+- Ship a `PowerStationQuiz` finder on the hub.
+- Centralize filtering in a new `lib/power-station-data.ts`.
+
+## Where to go next
+
+- **PMs:** [for-product-managers.md](./for-product-managers.md)
+- **Devs:** [for-developers.md](./for-developers.md)
+- **Designers:** [for-designers.md](./for-designers.md)
+- **Editors:** [for-content-editors.md](./for-content-editors.md)

--- a/docs/reference/components.md
+++ b/docs/reference/components.md
@@ -1,0 +1,145 @@
+# Reference — Component Catalog
+
+A quick index of every component in `components/` with its purpose and the props that matter most. For exact prop types, open the source file — this catalog favors usefulness over exhaustive type signatures.
+
+## Layout & chrome
+
+| Component | File | Purpose |
+|---|---|---|
+| `Header` | `components/Header.tsx` | Top nav, logo, category dropdown, sticky on scroll |
+| `Footer` | `components/Footer.tsx` | Footer links, social, copyright |
+| `Breadcrumb` | `components/Breadcrumb.tsx` | Breadcrumb trail (`Home › Best › Power Stations › RV`) |
+| `CategoryDropdown` | `components/CategoryDropdown.tsx` | Mobile-friendly category nav |
+| `SearchBar` | `components/SearchBar.tsx` | Client-side search/filter (`'use client'`) |
+
+## Product surfaces
+
+### `RankedProductCard`
+
+`components/RankedProductCard.tsx` — the workhorse of category pages.
+
+```tsx
+<RankedProductCard
+  rank={1}
+  name="EcoFlow Delta 3 Plus"
+  href="/articles/ecoflow_delta_3_plus"
+  image="https://..."
+  summary="One-paragraph hook."
+  score={9.2}
+  price="$999"
+  badge="best-overall"           // 'best-overall' | 'best-value' | 'budget-pick'
+  buyUrl="https://amazon.com/..."
+  specs={{ Capacity: "1024 Wh" }}
+/>
+```
+
+Stretched-link card (whole card is clickable). Lift + shadow on hover. CTA morphs on hover.
+
+### `ReviewCard`
+
+Compact home-page card. Same shape, smaller surface.
+
+### `QuickPicks`
+
+Three-up grid for "Best Overall / Best Value / Budget Pick" — feed it the output of `getQuickPicks(entries)`.
+
+### `ComparisonCard`
+
+```tsx
+<ComparisonCard
+  a={stationA}          // PowerStationEntry
+  b={stationB}          // PowerStationEntry
+  verdict="The Delta 3 Plus wins on recharge speed; the C1000 wins on value."
+  buyA="https://..."
+  buyB="https://..."
+/>
+```
+
+Side-by-side spec table with winning rows tinted `--primary-light`. Numeric-leading spec values are parsed via `extractNum()` to compute the winner.
+
+## Article components (`components/article/`)
+
+| Component | Purpose |
+|---|---|
+| `ArticleContent` | Wraps the rendered markdown body with `.article-body` styling |
+| `ProductSpecs` | Renders the `specs` object as a definition list |
+| `ProsCons` | Two-column pros / cons lists |
+| `ProductImage` | Hero product image |
+| `ScoreCard` | Large numeric score + metric breakdown |
+| `StarRating` | 0–5 star visual derived from a 0–10 score |
+| `RatingBadge` | Compact score badge |
+| `PriceButton` / `RetailerLinks` | Buy-now CTAs from `retailerLinks` |
+| `AuthorBio` | Byline + bio block |
+| `RelatedArticles` | Links to other reviews in the same category |
+| `TableOfContents` | Auto-generated from H2/H3 anchors |
+| `StickyBuyBar` | Fixed bottom bar with price + buy button (`'use client'`) |
+
+## Interactive
+
+### `PowerStationQuiz`
+
+`'use client'`. Three-question finder. State machine inside the component; routing matrix in `getRoute(answers)` returns a sub-category URL. Submit disabled until all three answered.
+
+### `Newsletter`
+
+Single-input email signup, inline validation, no modal.
+
+### `Top10Popular`
+
+Sidebar widget rendering the top 10 by score across the catalog.
+
+## Badges & labels
+
+| Component | Purpose |
+|---|---|
+| `ScoreBadge` | Circular score badge, color ramped by value |
+| `AwardBadge` | `best-overall` / `best-value` / `budget-pick` chips |
+| `SectionLabel` | Uppercase section heading (e.g. "EDITOR'S PICK") |
+| `VerdictBox` | Styled verdict callout |
+| `BuyBox` | Price + buy-button container |
+
+## Utility
+
+### `OptimizedImage`
+
+Thin wrapper around `next/image` that adds:
+
+- Fallback image on error.
+- Loading placeholder.
+- Reliable width/height (so CLS stays near zero).
+
+**Always use this instead of raw `<img>` or even bare `next/image`.**
+
+### `card.tsx`
+
+Generic card primitive (shadcn-style). Use it as the base for new card-shaped UIs.
+
+## Ads (`components/ads/`)
+
+### `AdBanner`
+
+```tsx
+<AdBanner adSlot="articleTop" adFormat="rectangle" />
+```
+
+- `adSlot` must exist in `ADSENSE_CONFIG` (`lib/adsense-config.ts`).
+- `adFormat`: `'rectangle' | 'leaderboard' | 'banner' | 'vertical' | 'auto'`.
+- Renders a labeled placeholder in dev; real AdSense unit in prod when the publisher ID is set.
+
+### `ResponsiveAd`
+
+Adaptive wrapper that swaps between mobile/desktop slots based on viewport.
+
+## Picking the right component
+
+| You want to… | Reach for |
+|---|---|
+| Show a ranked product on a category page | `RankedProductCard` |
+| Show the top 3 with award badges | `QuickPicks` |
+| Compare two products side-by-side | `ComparisonCard` |
+| Show a single product in a list (home) | `ReviewCard` |
+| Display the overall score and breakdown | `ScoreCard` + `StarRating` |
+| Render a markdown body | `ArticleContent` (and let the pipeline do the work) |
+| Insert an ad | `AdBanner` (never inline AdSense code) |
+| Insert any image | `OptimizedImage` |
+| Build a new card-shaped UI | Start from `card.tsx`, extend with `class-variance-authority` |

--- a/docs/reference/content-schema.md
+++ b/docs/reference/content-schema.md
@@ -1,0 +1,161 @@
+# Reference — Content Schema
+
+The complete frontmatter schema for review files at `posts/<category>/<slug>.md`.
+
+## Required fields
+
+| Field | Type | Example | Notes |
+|---|---|---|---|
+| `title` | string | `"EcoFlow Delta 3 Plus"` | Product name. Becomes `<h1>` and `<title>` |
+| `date` | ISO date string | `"2026-04-10"` | Publication date. Used for sort order and OG metadata |
+| `price` | string | `"$999"`, `"$799–$999"` | Free-form display string. Ranges allowed |
+| `productImage` | URL | `"https://.../delta3plus.jpg"` | Primary hero image. Must be on a whitelisted domain |
+| `specs` | object | see below | Key–value spec table |
+| `pros` | string[] | `["Fast charging", "Quiet"]` | Bulleted strengths |
+| `cons` | string[] | `["Heavy"]` | Bulleted weaknesses |
+| `retailerLinks` | object | see below | Affiliate links by retailer name |
+| `ratingBreakdown.metrics` | array | see below | Scored criteria, averaged into the overall score |
+
+## Optional fields
+
+| Field | Type | Example | Notes |
+|---|---|---|---|
+| `subtitle` | string | `"A 1 kWh powerhouse..."` | One-line hook below the title |
+| `author` | string | `"Jane Doe"` | Byline |
+| `authorBio` | string | `"Jane has reviewed..."` | Used by `AuthorBio` component |
+| `image` | URL | | Fallback image if `productImage` is missing |
+| `heroImage` | URL | | Optional alternative hero (some templates) |
+| `rating` | number | `8.7` | Legacy single score; **deprecated** — prefer `ratingBreakdown` |
+
+## Category-specific fields
+
+### Power stations (`posts/portable-power-stations/*.md`)
+
+| Field | Type | Allowed values | Used by |
+|---|---|---|---|
+| `capacityWh` | number | `0`–`∞` (no units) | `under-500`, `under-1000`, `for-cpap`, sort orders |
+| `features` | string[] | see tag table below | All filtered sub-category pages |
+
+**Feature tags:**
+
+| Tag | Apply when… |
+|---|---|
+| `30a-rv` | Product has a TT-30 (30A) RV outlet |
+| `solar` | Solar input ≥ 200W |
+| `solar-kit` | Bundled with a solar panel |
+| `240v` | Has true 240V output |
+| `cpap` | 500–1500 Wh, < 25 lbs, quiet enough for bedside use |
+| `van-life` | < 30 lbs **and** ≥ 400W solar input |
+
+## Nested shapes
+
+### `specs`
+
+Free-form object — keys are display labels.
+
+```yaml
+specs:
+  Capacity: "1024 Wh"
+  AC Output: "1800 W"
+  Solar Input: "500 W"
+  Weight: "27 lbs"
+  Recharge Time: "56 min"
+```
+
+**Tip:** keep keys consistent across reviews in the same category so the comparison page tables line up cleanly. The comparison card's "winner" highlight uses `extractNum()` to parse the value — keep numeric values numeric-leading (e.g. `"27 lbs"`, not `"weighs 27 lbs"`).
+
+### `retailerLinks`
+
+```yaml
+retailerLinks:
+  Amazon: "https://www.amazon.com/dp/XXXX?tag=YOURTAG"
+  BestBuy: "https://www.bestbuy.com/site/..."
+  EcoFlow: "https://us.ecoflow.com/..."
+```
+
+- Keys are retailer display names.
+- All URLs are validated by `isSafeUrl()` at render time.
+- All outbound links get `rel="noopener noreferrer nofollow"` and `target="_blank"`.
+
+### `ratingBreakdown`
+
+```yaml
+ratingBreakdown:
+  metrics:
+    - name: "Performance"
+      score: 9.2
+    - name: "Design & Build"
+      score: 8.5
+    - name: "Value"
+      score: 8.0
+    - name: "App & Features"
+      score: 7.5
+```
+
+- `score` is on a **0–10 scale**, decimals allowed.
+- The article's overall score is the **arithmetic mean** of all `score` values (`lib/articleUtils.ts → calculateOverallScore`).
+- Stars (0–5) are derived as `score / 2` (`scoreToStarRating`).
+
+**Recommended metric vocab** (for consistency within a category):
+
+- Performance, Design & Build, Value, App & Features
+- Battery / Runtime (when relevant)
+- Sound (audio), Image / Display (visual), Ergonomics (input devices)
+
+## Slug & filename rules
+
+- Filename is the URL slug. `delta_3_plus.md` → `/articles/delta_3_plus`.
+- Must match `/^[a-z0-9]+(?:[_-][a-z0-9]+)*$/i`.
+- Lowercase only, no spaces, no special characters.
+
+## Validation
+
+There is no schema validator today — invalid frontmatter typically manifests as:
+
+- Build error from `gray-matter` (malformed YAML).
+- Runtime fall-through (missing field renders blank in the UI).
+- Type error if a component reads a required field as non-optional.
+
+When adding a new required field, also update the `PostMetadata` TypeScript interface in `components/PostMetadata.ts`.
+
+## Worked example
+
+```markdown
+---
+title: "Anker SOLIX C1000"
+subtitle: "The benchmark for sub-$1000 portable power"
+date: "2026-03-14"
+author: "Sam Kim"
+price: "$799"
+productImage: "https://example.s3.amazonaws.com/anker-c1000.jpg"
+capacityWh: 1056
+features:
+  - "solar"
+  - "cpap"
+specs:
+  Capacity: "1056 Wh"
+  AC Output: "1800 W"
+  Solar Input: "600 W"
+  Weight: "28.4 lbs"
+pros:
+  - "Best-in-class fast charging"
+  - "Excellent app experience"
+  - "Quiet under load"
+cons:
+  - "No 240V output"
+  - "Carry handle could be sturdier"
+retailerLinks:
+  Amazon: "https://www.amazon.com/dp/XXXX?tag=YOURTAG"
+  Anker: "https://www.anker.com/products/a1761"
+ratingBreakdown:
+  metrics:
+    - { name: "Performance", score: 9.0 }
+    - { name: "Design & Build", score: 8.5 }
+    - { name: "Value", score: 9.5 }
+    - { name: "App & Features", score: 9.0 }
+---
+
+## Verdict
+
+The C1000 is the easiest recommendation in its bracket...
+```

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -1,0 +1,98 @@
+# Reference — Route Map
+
+Every route in the app, what it renders, and how it's generated.
+
+## Home & meta
+
+| Route | File | Rendering |
+|---|---|---|
+| `/` | `app/page.tsx` | Static — home with editor's pick, latest, best-of, sidebar |
+| `/sitemap.xml` | `app/sitemap.ts` | `force-static` — auto-enumerates all routes |
+| `/robots.txt` | `app/robots.ts` | `force-static` |
+
+## Articles
+
+| Route | File | Rendering |
+|---|---|---|
+| `/articles/[slug]` | `app/articles/[slug]/page.tsx` | SSG via `generateStaticParams()` over `getAllPostSlugs()` |
+
+Each article also emits per-route OG metadata and a JSON-LD `Review` schema.
+
+## Best (category hub)
+
+| Route | File | Notes |
+|---|---|---|
+| `/best` | `app/best/page.tsx` | Top-level hub: featured categories, methodology, browse-all |
+
+## Best — Power Stations
+
+| Route | File | Filter |
+|---|---|---|
+| `/best/power-stations` | `app/best/power-stations/page.tsx` | Hub: hero, finder quiz, sub-category grid |
+| `/best/power-stations/portable-power-stations` | `…/portable-power-stations/page.tsx` | All portable stations |
+| `/best/power-stations/house-backup-power-stations` | `…/house-backup-power-stations/page.tsx` | Whole-home backup |
+| `/best/power-stations/camping-power-stations` | `…/camping-power-stations/page.tsx` | Camping |
+| `/best/power-stations/carry-on-power-stations` | `…/carry-on-power-stations/page.tsx` | Travel-sized |
+| `/best/power-stations/rv-power-stations` | `…/rv-power-stations/page.tsx` | `features` includes `30a-rv` |
+| `/best/power-stations/solar-generators` | `…/solar-generators/page.tsx` | `features` includes `solar` or `solar-kit` |
+| `/best/power-stations/under-500` | `…/under-500/page.tsx` | Price ≤ $500 |
+| `/best/power-stations/under-1000` | `…/under-1000/page.tsx` | Price ≤ $1,000 |
+| `/best/power-stations/for-cpap` | `…/for-cpap/page.tsx` | `features` includes `cpap` |
+| `/best/power-stations/240v-power-stations` | `…/240v-power-stations/page.tsx` | `features` includes `240v` |
+| `/best/power-stations/van-life` | `…/van-life/page.tsx` | `features` includes `van-life` |
+
+### Power Station comparisons
+
+| Route | Comparison |
+|---|---|
+| `/best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000` | Mid-size, 1 kWh class |
+| `/best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2` | Mid-large, 2 kWh class |
+| `/best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10` | Flagship / whole-home |
+
+## Best — other verticals
+
+| Route | Notes |
+|---|---|
+| `/best/cameras` | Hub: hybrid, pro photo, pro generic |
+| `/best/cameras/hybrid-cameras` | Sub |
+| `/best/cameras/professional-photo-cameras` | Sub |
+| `/best/cameras/professional-cameras` | Sub |
+| `/best/gaming` | Hub: keyboards, mice |
+| `/best/gaming/gaming-keyboards` | Sub |
+| `/best/gaming/gaming-mice` | Sub |
+| `/best/headphones` | Hub |
+| `/best/headphones/noise-cancelling-headphones` | Sub |
+| `/best/headphones/wireless-earbuds` | Sub |
+| `/best/laptops` | Hub |
+| `/best/laptops/laptops-under-1000` | Sub |
+| `/best/laptops/gaming-laptops` | Sub |
+| `/best/laptops/macbooks` | Sub |
+| `/best/monitors` | Hub |
+| `/best/monitors/4k-monitors` | Sub |
+| `/best/monitors/gaming-monitors` | Sub |
+| `/best/smartphones` | Hub |
+| `/best/smart-home` | Hub |
+| `/best/smart-home/robot-vacuums` | Sub |
+| `/best/smart-home/smart-speakers` | Sub |
+| `/best/tvs` | Hub |
+| `/best/tvs/gaming-tvs` | Sub |
+| `/best/tvs/oled-tvs` | Sub |
+| `/best/wearables` | Hub |
+| `/best/wearables/smartwatches` | Sub |
+
+> Some sub-routes may exist as scaffolding without populated content yet. Check the directory under `app/best/` for the authoritative list.
+
+## How dynamic routes are precompiled
+
+- `app/articles/[slug]/page.tsx` exports `generateStaticParams()` which calls `getAllPostSlugs()` and returns `[{ slug }, …]`.
+- Comparison routes are explicit folders (not `[slug]`) because there are only three.
+- New comparison pages = new folders; new article pages happen automatically when a `.md` file is added.
+
+## Adding a new route
+
+| New thing you need | Steps |
+|---|---|
+| A new sub-category page | Create `app/best/<vertical>/<sub>/page.tsx`. Mirror an existing sibling. Add a card to the hub. |
+| A new comparison page | Create `app/best/<vertical>/compare/<a>-vs-<b>/page.tsx`. Pull entries with `getStationsBySlugs([...])`. |
+| A new vertical hub | Create `app/best/<vertical>/page.tsx` + at least one sub-category. Link from `/best`. Add to the header nav. |
+| A new article | Drop a `.md` file under `posts/<category>/`. No code change needed. |

--- a/docs/superpowers/plans/2025-05-06-power-station-category-expansion.md
+++ b/docs/superpowers/plans/2025-05-06-power-station-category-expansion.md
@@ -1,0 +1,1033 @@
+# Power Station Category Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a shared data layer, 7 new use-case category pages, 3 side-by-side comparison pages, and an inline 3-question finder quiz to the power station section of ProductLabR.
+
+**Architecture:** A new `lib/power-station-data.ts` reads all 33 markdown files in `posts/portable-power-stations/` at build time, filtering by two new frontmatter fields (`capacityWh` and `features[]`). Every new category page calls filter functions from this lib. The `PowerStationQuiz` client component lives inline on the hub page. The `ComparisonCard` server component is used by 3 new `/compare/` pages.
+
+**Tech Stack:** Next.js 16 App Router (SSG), TypeScript strict, Tailwind CSS, gray-matter, existing components: `RankedProductCard`, `QuickPicks`, `Breadcrumb`, `SectionLabel`, `Newsletter`, `AdBanner`.
+
+---
+
+## File Map
+
+**New files:**
+- `lib/power-station-data.ts` — data layer: reads markdown, exports filter functions
+- `components/PowerStationQuiz.tsx` — `'use client'` quiz component (3 questions → router.push)
+- `components/ComparisonCard.tsx` — side-by-side product comparison component
+- `app/best/power-stations/rv-power-stations/page.tsx`
+- `app/best/power-stations/solar-generators/page.tsx`
+- `app/best/power-stations/under-500/page.tsx`
+- `app/best/power-stations/under-1000/page.tsx`
+- `app/best/power-stations/for-cpap/page.tsx`
+- `app/best/power-stations/240v-power-stations/page.tsx`
+- `app/best/power-stations/van-life/page.tsx`
+- `app/best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000/page.tsx`
+- `app/best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2/page.tsx`
+- `app/best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10/page.tsx`
+
+**Modified files:**
+- `components/PostMetadata.ts` — add `capacityWh?: number` and `features?: string[]`
+- `app/best/power-stations/page.tsx` — add `PowerStationQuiz` + update category grid
+- All 33 `posts/portable-power-stations/*.md` — add `capacityWh` + `features[]` frontmatter
+- 12 short reviews (<150 lines) — expand to 200–250 lines
+
+---
+
+## Task 1: Extend PostMetadata type
+
+**Files:**
+- Modify: `components/PostMetadata.ts`
+
+- [ ] **Add `capacityWh` and `features` to the interface**
+
+```ts
+// components/PostMetadata.ts
+export interface PostMetadata {
+    title: string;
+    date: string;
+    subtitle: string;
+    slug: string;
+    image?: string;
+    heroImage?: string;
+    productImage?: string;
+    author?: string;
+    specs?: Record<string, string>;
+    pros?: string[];
+    cons?: string[];
+    authorBio?: string;
+    price?: string;
+    rating?: number;
+    retailerLinks?: Record<string, string>;
+    category?: string;
+    capacityWh?: number;
+    features?: string[];
+    ratingBreakdown?: {
+      overallScore?: number;
+      overallRank?: string;
+      metrics: { name: string; score: number }[];
+    };
+  }
+```
+
+- [ ] **Run type-check to verify no regressions**
+
+```bash
+npm run type-check
+```
+
+Expected: clean output, no errors.
+
+- [ ] **Commit**
+
+```bash
+git add components/PostMetadata.ts
+git commit -m "feat(types): add capacityWh and features to PostMetadata"
+```
+
+---
+
+## Task 2: Add frontmatter fields to all 33 reviews
+
+**Files:**
+- Modify: all files in `posts/portable-power-stations/*.md`
+
+Add `capacityWh` (number, in Wh) and `features` (array of tag strings) to the YAML frontmatter of every review. Place them directly after the existing `date:` field.
+
+**Feature tag reference:**
+- `"30a-rv"` — has a 30A RV outlet
+- `"solar"` — solar input ≥ 800W
+- `"solar-kit"` — sold as/commonly paired with solar panels
+- `"240v"` — supports 240V output
+- `"cpap"` — suitable for CPAP (500–1500Wh + weight < 25 lbs)
+- `"van-life"` — compact + solar capable (weight < 30 lbs + solar ≥ 400W)
+
+**Complete mapping for all 33 files:**
+
+| File | capacityWh | features |
+|---|---|---|
+| anker_powercore_26800_pd.md | 99 | [] |
+| anker_solix_c1000.md | 1056 | ["solar", "van-life"] |
+| anker_solix_c2000_gen2.md | 2048 | ["30a-rv", "solar"] |
+| anker_solix_e10.md | 6144 | ["240v", "30a-rv"] |
+| anker_solix_f3800.md | 3840 | ["30a-rv", "solar", "240v"] |
+| anker_solix_f3800_plus.md | 3840 | ["30a-rv", "solar", "240v"] |
+| anker_solix_c800.md | 768 | ["van-life", "cpap"] |
+| bluetti_ac180.md | 1152 | ["solar", "cpap"] |
+| bluetti_ac_180.md | 1152 | ["solar", "cpap"] |
+| bluetti_ac300_b300.md | 3072 | ["solar-kit", "30a-rv"] |
+| bluetti_apex_300.md | 2764 | ["solar", "240v"] |
+| bluetti_eb70s.md | 716 | ["van-life", "cpap"] |
+| bluetti_elite_200_v2.md | 2073 | ["solar"] |
+| bluetti_elite_300.md | 3014 | ["30a-rv", "solar"] |
+| bluetti_elite_400.md | 3840 | ["solar", "30a-rv"] |
+| dji_power_1000.md | 1024 | ["van-life", "cpap"] |
+| ecoflow_delta_3.md | 1024 | ["solar", "van-life"] |
+| ecoflow_delta_3_max.md | 2048 | ["solar"] |
+| ecoflow_delta_3_plus.md | 1024 | ["solar", "van-life"] |
+| ecoflow_delta_3_ultra_plus.md | 3072 | ["solar", "30a-rv"] |
+| ecoflow_delta_pro_3.md | 4096 | ["30a-rv", "solar", "240v"] |
+| ecoflow_delta_pro_ultra_x.md | 6144 | ["solar", "240v"] |
+| ecoflow_river_2_pro.md | 768 | ["van-life", "cpap", "solar"] |
+| goal_zero_sherpa_100ac.md | 100 | [] |
+| goal_zero_yeti_500x.md | 500 | ["solar-kit", "van-life"] |
+| goal_zero_yeti_6000x.md | 6071 | ["solar-kit", "30a-rv"] |
+| jackery_explorer_1000_v2.md | 1070 | ["solar", "van-life"] |
+| jackery_explorer_1500_ultra.md | 1536 | ["solar", "van-life"] |
+| jackery_homepower_3600_plus.md | 3584 | ["30a-rv", "solar", "240v"] |
+| oupes_guardian_6000.md | 4608 | ["240v", "30a-rv", "solar"] |
+| oupes_mega_5.md | 5040 | ["30a-rv", "solar"] |
+| pecron_e3800.md | 3840 | ["solar", "30a-rv", "240v"] |
+| ravpower_90w_ac_power_bank.md | 90 | [] |
+
+- [ ] **Add frontmatter to each file** — open each file and add after `date:`:
+
+```yaml
+capacityWh: <NUMBER>
+features:
+  - "<tag1>"
+  - "<tag2>"
+```
+
+Example for `anker_solix_c2000_gen2.md`:
+```yaml
+date: "2025-03-28"
+capacityWh: 2048
+features:
+  - "30a-rv"
+  - "solar"
+```
+
+- [ ] **Verify frontmatter parses correctly**
+
+```bash
+node -e "
+const matter = require('gray-matter');
+const fs = require('fs');
+const files = fs.readdirSync('posts/portable-power-stations').filter(f => f.endsWith('.md'));
+files.forEach(f => {
+  const { data } = matter(fs.readFileSync('posts/portable-power-stations/' + f, 'utf8'));
+  if (!data.capacityWh || !data.features) console.log('MISSING:', f);
+});
+console.log('Done. Files checked:', files.length);
+"
+```
+
+Expected: `Done. Files checked: 33` with no MISSING lines.
+
+- [ ] **Commit**
+
+```bash
+git add posts/portable-power-stations/
+git commit -m "feat(content): add capacityWh and features frontmatter to all 33 power station reviews"
+```
+
+---
+
+## Task 3: Expand 12 short reviews to 200–250 lines
+
+**Files:**
+- Modify: the 12 reviews under 150 lines (identified below)
+
+- [ ] **Identify short reviews**
+
+```bash
+wc -l posts/portable-power-stations/*.md | sort -n | head -15
+```
+
+The 12 shortest files (all written in this session) will be at the top. Target: every file ≥ 200 lines.
+
+- [ ] **For each short review, expand using this structure:**
+
+Each review must have ALL of these sections to reach 200–250 lines:
+
+1. **Introduction** (3 paragraphs) — market positioning, who it's for, what makes it stand out
+2. **Unboxing & First Impressions** (2 paragraphs) — build quality, what's in box, ergonomics
+3. **Key Features** (H3 per feature, 2 paragraphs each) — 4–5 features covered in depth with real-world context
+4. **Performance Testing** (2–3 paragraphs) — specific numbers, comparisons to rated specs
+5. **Competitive Analysis** (1 paragraph per rival, 2–3 rivals) — explicit trade-off statements
+6. **Who It's For** — ✅ / ❌ bullet lists
+7. **Final Verdict** (1–2 paragraphs + buy/don't-buy bullets)
+8. **FAQ** (3–5 Q&A pairs)
+
+- [ ] **After expanding, verify line counts**
+
+```bash
+wc -l posts/portable-power-stations/*.md | sort -n | head -15
+```
+
+Expected: all files ≥ 200 lines.
+
+- [ ] **Run type-check**
+
+```bash
+npm run type-check
+```
+
+Expected: clean.
+
+- [ ] **Commit**
+
+```bash
+git add posts/portable-power-stations/
+git commit -m "feat(content): expand 12 power station reviews to 200-250 line standard"
+```
+
+---
+
+## Task 4: Build the data layer
+
+**Files:**
+- Create: `lib/power-station-data.ts`
+
+- [ ] **Create the file**
+
+```ts
+// lib/power-station-data.ts
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { cache } from 'react';
+
+export interface PowerStationEntry {
+  slug: string;
+  title: string;
+  subtitle: string;
+  date: string;
+  price: string;
+  priceNum: number;
+  image: string;
+  capacityWh: number;
+  features: string[];
+  score: number;
+  specs: Record<string, string>;
+  pros: string[];
+  cons: string[];
+  retailerLinks: Record<string, string>;
+}
+
+const POSTS_DIR = path.join(process.cwd(), 'posts', 'portable-power-stations');
+
+function parsePrice(price: string): number {
+  const match = price.replace(/,/g, '').match(/\$(\d+)/);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+function calcScore(ratingBreakdown?: { metrics: { score: number }[] }): number {
+  if (!ratingBreakdown?.metrics?.length) return 0;
+  const avg = ratingBreakdown.metrics.reduce((sum, m) => sum + m.score, 0) / ratingBreakdown.metrics.length;
+  return Math.round(avg * 10) / 10;
+}
+
+export const getAllPowerStations = cache((): PowerStationEntry[] => {
+  const files = fs.readdirSync(POSTS_DIR).filter((f) => f.endsWith('.md'));
+  return files
+    .map((file) => {
+      const slug = file.replace('.md', '');
+      const raw = fs.readFileSync(path.join(POSTS_DIR, file), 'utf8');
+      const { data } = matter(raw);
+      return {
+        slug,
+        title: data.title ?? slug,
+        subtitle: data.subtitle ?? '',
+        date: data.date ?? '',
+        price: data.price ?? '',
+        priceNum: parsePrice(data.price ?? ''),
+        image: data.productImage ?? data.image ?? '/images/item.png',
+        capacityWh: data.capacityWh ?? 0,
+        features: data.features ?? [],
+        score: calcScore(data.ratingBreakdown),
+        specs: data.specs ?? {},
+        pros: data.pros ?? [],
+        cons: data.cons ?? [],
+        retailerLinks: data.retailerLinks ?? {},
+      } satisfies PowerStationEntry;
+    })
+    .sort((a, b) => b.score - a.score);
+});
+
+export function getStationsByFeature(feature: string): PowerStationEntry[] {
+  return getAllPowerStations().filter((s) => s.features.includes(feature));
+}
+
+export function getStationsUnderPrice(maxPrice: number): PowerStationEntry[] {
+  return getAllPowerStations().filter((s) => s.priceNum > 0 && s.priceNum <= maxPrice);
+}
+
+export function getStationsBySlugs(slugs: string[]): PowerStationEntry[] {
+  const all = getAllPowerStations();
+  return slugs.map((slug) => all.find((s) => s.slug === slug)).filter(Boolean) as PowerStationEntry[];
+}
+
+export function getQuickPicks(entries: PowerStationEntry[]): {
+  label: string; name: string; href: string; score: number; price: string;
+}[] {
+  const sorted = [...entries].sort((a, b) => b.score - a.score);
+  const picks = [
+    { label: 'Best Overall', entry: sorted[0] },
+    { label: 'Best Value', entry: sorted.find((s, i) => i > 0 && s.priceNum < (sorted[0]?.priceNum ?? 0)) ?? sorted[1] },
+    { label: 'Budget Pick', entry: [...entries].sort((a, b) => a.priceNum - b.priceNum)[0] },
+  ];
+  return picks
+    .filter((p) => p.entry)
+    .map((p) => ({
+      label: p.label,
+      name: p.entry!.title,
+      href: `/articles/${p.entry!.slug}`,
+      score: p.entry!.score,
+      price: p.entry!.price,
+    }));
+}
+```
+
+- [ ] **Run type-check**
+
+```bash
+npm run type-check
+```
+
+Expected: clean.
+
+- [ ] **Commit**
+
+```bash
+git add lib/power-station-data.ts
+git commit -m "feat(data): add power-station-data lib with filter functions"
+```
+
+---
+
+## Task 5: Build 7 category pages
+
+**Files:**
+- Create: 7 `page.tsx` files under `app/best/power-stations/`
+
+Each page follows this exact template. Substitute the bracketed values per category.
+
+- [ ] **Create `rv-power-stations/page.tsx`**
+
+```tsx
+// app/best/power-stations/rv-power-stations/page.tsx
+import { Metadata } from 'next';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { QuickPicks } from '@/components/QuickPicks';
+import { RankedProductCard } from '@/components/RankedProductCard';
+import { Newsletter } from '@/components/Newsletter';
+import AdBanner from '@/components/ads/AdBanner';
+import { ADSENSE_CONFIG } from '@/lib/adsense-config';
+import { getStationsByFeature, getQuickPicks } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'Best Power Stations for RV 2025 — 30A & Solar Ready',
+  description: 'Top-rated power stations with 30A RV outlets and solar charging. Expert tested for RV and trailer use.',
+};
+
+export default function RVPowerStations() {
+  const stations = getStationsByFeature('30a-rv');
+  const quickPicks = getQuickPicks(stations);
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: 'RV Power Stations' },
+      ]} />
+      <div className="bg-gradient-to-br from-primary to-primary-dark px-6 py-10 text-white">
+        <div className="mx-auto max-w-content">
+          <SectionLabel className="text-white/70">Buying Guide</SectionLabel>
+          <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">Best Power Stations for RV 2025</h1>
+          <p className="mt-2 max-w-2xl text-base text-white/80">
+            Power stations with genuine 30A RV outlets and solar charging — expert tested for full-time RV and trailer use.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {['30A RV Outlet', 'Solar Ready', 'High Capacity'].map((tag) => (
+              <span key={tag} className="rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs text-white/90">{tag}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <QuickPicks picks={quickPicks} />
+            <div>
+              <SectionLabel>Ranked List</SectionLabel>
+              <div className="space-y-4">
+                {stations.map((station, i) => (
+                  <div key={station.slug}>
+                    <RankedProductCard
+                      rank={i + 1}
+                      name={station.title}
+                      href={`/articles/${station.slug}`}
+                      image={station.image}
+                      summary={station.subtitle}
+                      score={station.score}
+                      price={station.price}
+                      specs={station.specs}
+                    />
+                    {i === 2 && (
+                      <div className="mt-4">
+                        <AdBanner adSlot={ADSENSE_CONFIG.adSlots.categoryBottom} adFormat="auto" className="rounded-lg" />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-6">
+              <SectionLabel>Buying Guide</SectionLabel>
+              <h2 className="mb-4 text-lg font-bold text-neutral-900">Choosing a Power Station for Your RV</h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {[
+                  { title: '30A vs 50A Service', items: ['Most RVs use 30A (3,600W) service', '50A RVs need 240V split-phase — verify your unit supports it', 'Check the outlet type: TT-30 (30A) vs NEMA 14-50 (50A)', 'Inverter must exceed 3,600W to fully support 30A loads'] },
+                  { title: 'Solar for RV Use', items: ['800W+ solar input recommended for full-day use', 'Dual solar ports allow mixed panel configurations', 'MPPT charge controllers maximize efficiency', 'Budget 200W of panels per 1,000Wh of battery capacity'] },
+                ].map((section) => (
+                  <div key={section.title}>
+                    <h3 className="mb-2 text-sm font-semibold text-primary">{section.title}</h3>
+                    <ul className="space-y-1">{section.items.map((item) => <li key={item} className="text-xs text-neutral-600">• {item}</li>)}</ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </main>
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Jump To</h3>
+              <ul className="space-y-2 text-sm">
+                {stations.slice(0, 8).map((s, i) => (
+                  <li key={s.slug}><a href={`#rank-${i + 1}`} className="text-neutral-600 hover:text-primary">#{i + 1} {s.title}</a></li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-xl bg-gradient-to-br from-primary-lightest to-primary-light/20 p-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-primary">30A vs 50A Guide</h3>
+              <div className="space-y-2 text-xs text-neutral-600">
+                <p><strong className="text-primary">30A RV (most common):</strong> TT-30 plug, 120V only, max 3,600W. Most power stations with a "30A outlet" target this.</p>
+                <p><strong className="text-primary">50A RV:</strong> NEMA 14-50, 240V split-phase, up to 12,000W. Requires a 240V-capable unit like the OUPES Guardian 6000 or Anker F3800 Plus.</p>
+              </div>
+            </div>
+            <AdBanner adSlot={ADSENSE_CONFIG.adSlots.sidebar} adFormat="rectangle" style={{ minHeight: 250 }} className="rounded-lg" />
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Create `solar-generators/page.tsx`** — same template, change:
+  - `getStationsByFeature('solar')` (union with `solar-kit`: `[...getStationsByFeature('solar'), ...getStationsByFeature('solar-kit')].filter((s, i, arr) => arr.findIndex(x => x.slug === s.slug) === i)`)
+  - Title: `'Best Solar Generators 2025 — Top Portable Solar Power Stations'`
+  - Tags: `['800W+ Solar Input', 'Off-Grid Ready', 'LiFePO4 Battery']`
+  - Sidebar widget: Solar sizing guide — "Rule of thumb: 200W of panels per 1,000Wh capacity"
+  - Buying guide sections: "How to size your solar array" + "MPPT vs PWM charge controllers"
+
+- [ ] **Create `under-500/page.tsx`** — change:
+  - `getStationsUnderPrice(500)`
+  - Title: `'Best Portable Power Stations Under $500 (2025)'`
+  - Tags: `['Under $500', 'Best Value', 'Expert Tested']`
+  - Sidebar: price band comparison table (static)
+  - Buying guide: "What you get at each price point" + "Budget vs mid-range trade-offs"
+
+- [ ] **Create `under-1000/page.tsx`** — change:
+  - `getStationsUnderPrice(1000)`
+  - Title: `'Best Portable Power Stations Under $1,000 (2025)'`
+  - Tags: `['Under $1,000', 'Mid-Range', 'Best Value']`
+  - Sidebar: value comparison — capacity vs price at each tier
+  - Buying guide: "1kWh vs 2kWh — what's the right size?" + "Key specs to prioritize at this budget"
+
+- [ ] **Create `for-cpap/page.tsx`** — change:
+  - `getStationsByFeature('cpap')`
+  - Title: `'Best Power Stations for CPAP Machines 2025'`
+  - Tags: `['CPAP Compatible', '500–1500Wh', 'Quiet Operation']`
+  - Sidebar: CPAP runtime calculator (static table — CPAP draws 30–60W, so 1,000Wh ÷ 45W avg = ~22 hours)
+  - Buying guide: "How many nights per charge?" + "DC mode vs AC mode for CPAP"
+
+- [ ] **Create `240v-power-stations/page.tsx`** — change:
+  - `getStationsByFeature('240v')`
+  - Title: `'Best 240V Portable Power Stations 2025'`
+  - Tags: `['240V Output', 'Split-Phase', 'Home Backup']`
+  - Sidebar: 240V use case guide (dryer/AC/EV charger wattage table)
+  - Buying guide: "What requires 240V?" + "Split-phase explained"
+
+- [ ] **Create `van-life/page.tsx`** — change:
+  - `getStationsByFeature('van-life')`
+  - Title: `'Best Power Stations for Van Life 2025'`
+  - Tags: `['Under 30 lbs', 'Solar Capable', 'Compact']`
+  - Sidebar: van power budget guide (fridge 50W + lights 20W + laptop 60W + misc 20W = ~150W/day = ~1,050Wh/week)
+  - Buying guide: "How to size for van life" + "Solar vs shore power strategy"
+
+- [ ] **Run type-check**
+
+```bash
+npm run type-check
+```
+
+Expected: clean.
+
+- [ ] **Run build to verify all 7 pages render**
+
+```bash
+npm run build 2>&1 | grep -E "rv-power|solar-gen|under-500|under-1000|for-cpap|240v|van-life"
+```
+
+Expected: all 7 routes appear as `○ (Static)`.
+
+- [ ] **Commit**
+
+```bash
+git add app/best/power-stations/rv-power-stations/ app/best/power-stations/solar-generators/ app/best/power-stations/under-500/ app/best/power-stations/under-1000/ app/best/power-stations/for-cpap/ app/best/power-stations/240v-power-stations/ app/best/power-stations/van-life/
+git commit -m "feat(pages): add 7 use-case power station category pages"
+```
+
+---
+
+## Task 6: Build ComparisonCard component
+
+**Files:**
+- Create: `components/ComparisonCard.tsx`
+
+- [ ] **Create the component**
+
+```tsx
+// components/ComparisonCard.tsx
+import { PowerStationEntry } from '@/lib/power-station-data';
+import { OptimizedImage } from './OptimizedImage';
+import { ScoreBadge } from './ScoreBadge';
+
+interface ComparisonCardProps {
+  a: PowerStationEntry;
+  b: PowerStationEntry;
+  verdict: string;
+  buyA: string;
+  buyB: string;
+}
+
+type SpecRow = { label: string; keyA: string; keyB: string; higherIsBetter: boolean };
+
+const SPEC_ROWS: SpecRow[] = [
+  { label: 'Capacity', keyA: 'Battery Capacity', keyB: 'Battery Capacity', higherIsBetter: true },
+  { label: 'Inverter', keyA: 'Inverter Power', keyB: 'Inverter Power', higherIsBetter: true },
+  { label: 'Solar Input', keyA: 'Solar Input', keyB: 'Solar Input', higherIsBetter: true },
+  { label: 'Weight', keyA: 'Weight', keyB: 'Weight', higherIsBetter: false },
+  { label: 'Efficiency', keyA: 'Efficiency', keyB: 'Efficiency', higherIsBetter: true },
+];
+
+function extractNum(val: string | undefined): number {
+  if (!val) return 0;
+  const match = val.replace(/,/g, '').match(/[\d.]+/);
+  return match ? parseFloat(match[0]) : 0;
+}
+
+export function ComparisonCard({ a, b, verdict, buyA, buyB }: ComparisonCardProps) {
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white overflow-hidden">
+      {/* Header */}
+      <div className="grid grid-cols-2 divide-x divide-neutral-200">
+        {[{ entry: a, buyUrl: buyA }, { entry: b, buyUrl: buyB }].map(({ entry, buyUrl }) => (
+          <div key={entry.slug} className="p-5 flex flex-col items-center text-center gap-3">
+            <div className="relative h-32 w-full">
+              <OptimizedImage src={entry.image} alt={entry.title} fill sizes="250px" className="object-contain" />
+            </div>
+            <h3 className="font-bold text-neutral-900 text-sm">{entry.title}</h3>
+            <div className="flex items-center gap-2">
+              <ScoreBadge score={entry.score} showLabel />
+              <span className="font-bold text-neutral-900">{entry.price}</span>
+            </div>
+            <a href={buyUrl} target="_blank" rel="noopener noreferrer nofollow"
+              className="inline-flex items-center rounded-md bg-accent px-4 py-1.5 text-xs font-semibold text-white hover:bg-accent/90">
+              Buy Now →
+            </a>
+          </div>
+        ))}
+      </div>
+
+      {/* Spec table */}
+      <div className="border-t border-neutral-200">
+        <table className="w-full text-xs">
+          <tbody>
+            {SPEC_ROWS.map((row) => {
+              const valA = a.specs?.[row.keyA] ?? '—';
+              const valB = b.specs?.[row.keyB] ?? '—';
+              const numA = extractNum(valA);
+              const numB = extractNum(valB);
+              const aWins = numA !== numB && (row.higherIsBetter ? numA > numB : numA < numB);
+              const bWins = numA !== numB && (row.higherIsBetter ? numB > numA : numB < numA);
+              return (
+                <tr key={row.label} className="border-t border-neutral-100">
+                  <td className={`px-4 py-2.5 font-medium ${aWins ? 'bg-green-50 text-green-700' : 'text-neutral-700'}`}>{valA}</td>
+                  <td className="px-4 py-2.5 text-center text-neutral-400 text-[10px] font-semibold uppercase">{row.label}</td>
+                  <td className={`px-4 py-2.5 font-medium text-right ${bWins ? 'bg-green-50 text-green-700' : 'text-neutral-700'}`}>{valB}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pros / Cons */}
+      <div className="grid grid-cols-2 divide-x divide-neutral-200 border-t border-neutral-200">
+        {[a, b].map((entry) => (
+          <div key={entry.slug} className="p-4 space-y-2">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-green-600 mb-1">Pros</p>
+              <ul className="space-y-0.5">{entry.pros.slice(0, 3).map((p) => <li key={p} className="text-xs text-neutral-600">+ {p}</li>)}</ul>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-red-500 mb-1">Cons</p>
+              <ul className="space-y-0.5">{entry.cons.slice(0, 3).map((c) => <li key={c} className="text-xs text-neutral-600">− {c}</li>)}</ul>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Verdict */}
+      <div className="border-t border-neutral-200 bg-primary-lightest/40 p-5">
+        <p className="text-xs font-semibold uppercase tracking-wide text-primary mb-2">Verdict</p>
+        <p className="text-sm text-neutral-700 leading-relaxed">{verdict}</p>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Run type-check**
+
+```bash
+npm run type-check
+```
+
+Expected: clean.
+
+- [ ] **Commit**
+
+```bash
+git add components/ComparisonCard.tsx
+git commit -m "feat(components): add ComparisonCard side-by-side comparison component"
+```
+
+---
+
+## Task 7: Build 3 comparison pages
+
+**Files:**
+- Create: 3 `page.tsx` files under `app/best/power-stations/compare/`
+
+- [ ] **Create `ecoflow-delta-3-plus-vs-anker-solix-c1000/page.tsx`**
+
+```tsx
+// app/best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000/page.tsx
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { Breadcrumb } from '@/components/Breadcrumb';
+import { SectionLabel } from '@/components/SectionLabel';
+import { ComparisonCard } from '@/components/ComparisonCard';
+import { Newsletter } from '@/components/Newsletter';
+import { getStationsBySlugs } from '@/lib/power-station-data';
+
+export const metadata: Metadata = {
+  title: 'EcoFlow Delta 3 Plus vs Anker SOLIX C1000: Which Should You Buy? (2025)',
+  description: 'Side-by-side comparison of the EcoFlow Delta 3 Plus and Anker SOLIX C1000. Expert analysis of specs, performance, and value.',
+};
+
+export default function CompareEcoflowVsAnker() {
+  const [a, b] = getStationsBySlugs(['ecoflow_delta_3_plus', 'anker_solix_c1000']);
+
+  if (!a || !b) return null;
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Best Of', href: '/best' },
+        { label: 'Power Stations', href: '/best/power-stations' },
+        { label: 'Compare' },
+        { label: 'Delta 3 Plus vs C1000' },
+      ]} />
+      <div className="mx-auto max-w-content px-4 py-8 sm:px-6">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[7fr_3fr]">
+          <main className="space-y-6">
+            <div>
+              <SectionLabel>Head-to-Head</SectionLabel>
+              <h1 className="text-2xl font-extrabold text-neutral-900 mb-6">EcoFlow Delta 3 Plus vs Anker SOLIX C1000</h1>
+              <ComparisonCard
+                a={a}
+                b={b}
+                verdict="The EcoFlow Delta 3 Plus wins on UPS functionality, X-Boost technology, and ecosystem depth — worth the premium for home backup users who need smart home integration. The Anker SOLIX C1000 Gen 2 wins on value: nearly identical capacity at $449 with faster charging and better solar input. For most buyers prioritizing cost, Anker is the smarter choice."
+                buyA={a.retailerLinks?.Amazon ?? '#'}
+                buyB={b.retailerLinks?.Amazon ?? '#'}
+              />
+            </div>
+          </main>
+          <aside className="space-y-5">
+            <div className="rounded-xl border border-neutral-200 bg-white p-4">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Also Compare</h3>
+              <ul className="space-y-2 text-sm">
+                <li><Link href="/best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2" className="text-neutral-600 hover:text-primary">Bluetti Elite 200 V2 vs Anker C2000 Gen 2 →</Link></li>
+                <li><Link href="/best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10" className="text-neutral-600 hover:text-primary">EcoFlow Delta Pro Ultra X vs Anker SOLIX E10 →</Link></li>
+              </ul>
+            </div>
+            <Newsletter />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Create `bluetti-elite-200-v2-vs-anker-solix-c2000-gen2/page.tsx`** — same template, change:
+  - slugs: `['bluetti_elite_200_v2', 'anker_solix_c2000_gen2']`
+  - title: `'Bluetti Elite 200 V2 vs Anker SOLIX C2000 Gen 2: Which Should You Buy? (2025)'`
+  - verdict: `"The Bluetti Elite 200 V2 wins on efficiency (94% vs 89%) and solar input (1,000W vs 800W) — the right pick if you cycle daily or rely heavily on solar. The Anker SOLIX C2000 Gen 2 wins on price ($799 vs $1,099), display quality, outlet count, and weight — the better all-rounder for most buyers. If budget is the priority, Anker wins clearly."`
+  - "Also compare" links: the other two comparison pages
+
+- [ ] **Create `ecoflow-delta-pro-ultra-x-vs-anker-solix-e10/page.tsx`** — same template, change:
+  - slugs: `['ecoflow_delta_pro_ultra_x', 'anker_solix_e10']`
+  - title: `'EcoFlow Delta Pro Ultra X vs Anker SOLIX E10: Which Whole-Home System Wins? (2025)'`
+  - verdict: `"The EcoFlow Delta Pro Ultra X wins on raw inverter power (12kW vs 7.6kW) and solar input (10kW vs 9kW), making it the choice for the largest residential solar arrays. The Anker SOLIX E10 wins on installation simplicity (wireless battery connections), silent operation (passive cooling), and surge capacity (37kW vs inconsistent). For most homeowners, the Anker's installation advantage makes it the better choice."`
+  - "Also compare" links: the other two comparison pages
+
+- [ ] **Run build**
+
+```bash
+npm run build 2>&1 | grep "compare"
+```
+
+Expected: 3 comparison routes appear as `○ (Static)`.
+
+- [ ] **Commit**
+
+```bash
+git add app/best/power-stations/compare/
+git commit -m "feat(pages): add 3 model-vs-model comparison pages"
+```
+
+---
+
+## Task 8: Build PowerStationQuiz component
+
+**Files:**
+- Create: `components/PowerStationQuiz.tsx`
+
+- [ ] **Create the component**
+
+```tsx
+// components/PowerStationQuiz.tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+type Answer = string | null;
+
+const QUESTIONS = [
+  {
+    id: 'budget',
+    question: "What's your budget?",
+    options: [
+      { value: 'under-500', label: 'Under $500', icon: '💰' },
+      { value: '500-1000', label: '$500 – $1,000', icon: '💵' },
+      { value: '1000-2000', label: '$1,000 – $2,000', icon: '💳' },
+      { value: '2000-plus', label: '$2,000+', icon: '🏦' },
+    ],
+  },
+  {
+    id: 'use',
+    question: 'What will you primarily use it for?',
+    options: [
+      { value: 'camping', label: 'Camping & outdoors', icon: '⛺' },
+      { value: 'home', label: 'Home backup', icon: '🏠' },
+      { value: 'rv', label: 'RV & van life', icon: '🚐' },
+      { value: 'solar', label: 'Off-grid solar', icon: '☀️' },
+    ],
+  },
+  {
+    id: 'solar',
+    question: 'How important is solar charging?',
+    options: [
+      { value: 'essential', label: 'Essential', icon: '🌞' },
+      { value: 'nice', label: 'Nice to have', icon: '⛅' },
+      { value: 'no', label: 'Not needed', icon: '🔌' },
+    ],
+  },
+] as const;
+
+function getRoute(budget: string, use: string, solar: string): string {
+  if (budget === 'under-500') return '/best/power-stations/under-500';
+  if (solar === 'essential') return '/best/power-stations/solar-generators';
+  if (use === 'rv') return budget === '2000-plus' ? '/best/power-stations/rv-power-stations' : '/best/power-stations/rv-power-stations';
+  if (use === 'camping') return budget === '500-1000' ? '/best/power-stations/camping-power-stations' : '/best/power-stations/under-1000';
+  if (use === 'solar') return '/best/power-stations/solar-generators';
+  if (use === 'home' && budget === '2000-plus') return '/best/power-stations/house-backup-power-stations';
+  if (use === 'home') return '/best/power-stations/under-1000';
+  if (budget === '500-1000') return '/best/power-stations/under-1000';
+  if (budget === '1000-2000') return '/best/power-stations/portable-power-stations';
+  return '/best/power-stations/house-backup-power-stations';
+}
+
+export function PowerStationQuiz() {
+  const router = useRouter();
+  const [answers, setAnswers] = useState<Record<string, Answer>>({ budget: null, use: null, solar: null });
+
+  const allAnswered = Object.values(answers).every(Boolean);
+
+  function handleSubmit() {
+    if (!allAnswered) return;
+    router.push(getRoute(answers.budget!, answers.use!, answers.solar!));
+  }
+
+  return (
+    <div className="rounded-xl border border-primary-light bg-white p-6 shadow-sm">
+      <h2 className="text-base font-bold text-neutral-900 mb-1">Find Your Perfect Power Station</h2>
+      <p className="text-xs text-neutral-500 mb-5">Answer 3 questions and we'll point you to the right category.</p>
+      <div className="space-y-6">
+        {QUESTIONS.map((q, qi) => (
+          <div key={q.id}>
+            <p className="text-sm font-semibold text-neutral-700 mb-2">
+              <span className="mr-2 text-primary">{qi + 1}.</span>{q.question}
+            </p>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+              {q.options.map((opt) => {
+                const selected = answers[q.id] === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    onClick={() => setAnswers((prev) => ({ ...prev, [q.id]: opt.value }))}
+                    className={`rounded-lg border px-3 py-2.5 text-center text-xs font-medium transition-all ${
+                      selected
+                        ? 'border-primary bg-primary text-white shadow-md'
+                        : 'border-neutral-200 bg-neutral-50 text-neutral-700 hover:border-primary hover:bg-primary-lightest'
+                    }`}
+                  >
+                    <span className="block text-base mb-0.5">{opt.icon}</span>
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-6 flex items-center gap-3">
+        <button
+          onClick={handleSubmit}
+          disabled={!allAnswered}
+          className="rounded-md bg-accent px-5 py-2 text-sm font-semibold text-white transition-all hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          Find my power station →
+        </button>
+        <span className="text-xs text-neutral-400">
+          {Object.values(answers).filter(Boolean).length} of 3 answered
+        </span>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Run type-check**
+
+```bash
+npm run type-check
+```
+
+Expected: clean.
+
+- [ ] **Commit**
+
+```bash
+git add components/PowerStationQuiz.tsx
+git commit -m "feat(components): add PowerStationQuiz 3-question finder"
+```
+
+---
+
+## Task 9: Wire quiz into hub page + update category grid
+
+**Files:**
+- Modify: `app/best/power-stations/page.tsx`
+
+- [ ] **Add `PowerStationQuiz` import and inject between hero and categories**
+
+At the top of the file, add:
+```tsx
+import { PowerStationQuiz } from '@/components/PowerStationQuiz';
+```
+
+In the `<main>` section, add `<PowerStationQuiz />` directly before the `<div>` containing the categories `SectionLabel`:
+
+```tsx
+<main className="space-y-6">
+  <PowerStationQuiz />   {/* ← add this line */}
+  <div>
+    <SectionLabel>Categories</SectionLabel>
+    ...
+```
+
+- [ ] **Update `powerStationCategories` array to include the 7 new pages**
+
+Replace the existing 4-item array with all 11 categories:
+
+```tsx
+const powerStationCategories = [
+  { title: 'Portable Power Stations', description: 'Versatile power stations for camping, emergencies, and outdoor activities', href: '/best/power-stations/portable-power-stations', count: 10, priceRange: '$299 – $1,499', features: ['500Wh – 1,500Wh', 'Multiple ports', 'Solar charging', 'Portable design'] },
+  { title: 'House Backup Power Stations', description: 'High-capacity units for whole-home backup during outages', href: '/best/power-stations/house-backup-power-stations', count: 10, priceRange: '$1,199 – $7,699', features: ['3,000Wh+', 'Home integration', '240V capable', 'Extended runtime'] },
+  { title: 'RV Power Stations', description: 'Power stations with genuine 30A outlets and solar charging for RV and trailer use', href: '/best/power-stations/rv-power-stations', count: 8, priceRange: '$1,011 – $7,699', features: ['30A RV outlet', 'Solar ready', 'High capacity', 'Expandable'] },
+  { title: 'Solar Generators', description: 'High solar input units for off-grid and solar-primary setups', href: '/best/power-stations/solar-generators', count: 12, priceRange: '$399 – $7,699', features: ['800W+ solar', 'LiFePO4 battery', 'Off-grid ready', 'MPPT charging'] },
+  { title: 'Camping Power Stations', description: 'Compact and lightweight power solutions for outdoor adventures', href: '/best/power-stations/camping-power-stations', count: 6, priceRange: '$199 – $999', features: ['200Wh – 1,000Wh', 'Ultra-portable', 'Weather resistant', 'Silent operation'] },
+  { title: 'Van Life Power Stations', description: 'Compact, solar-capable units under 30 lbs built for life on the road', href: '/best/power-stations/van-life', count: 7, priceRange: '$399 – $1,099', features: ['Under 30 lbs', 'Solar capable', 'Compact', 'DC output'] },
+  { title: 'Under $500', description: 'Best portable power stations for every budget under $500', href: '/best/power-stations/under-500', count: 6, priceRange: '$99 – $499', features: ['Budget friendly', 'Essential features', 'Portable', 'Reliable brands'] },
+  { title: 'Under $1,000', description: 'Mid-range power stations offering the best value per dollar', href: '/best/power-stations/under-1000', count: 14, priceRange: '$299 – $999', features: ['Best value', 'Mid-range', '500Wh – 2,000Wh', 'Expert picks'] },
+  { title: '240V Power Stations', description: 'Power stations with split-phase 240V output for dryers, AC, and EV charging', href: '/best/power-stations/240v-power-stations', count: 5, priceRange: '$1,199 – $7,699', features: ['240V output', 'Split-phase', 'Heavy loads', 'Home backup'] },
+  { title: 'CPAP Power Stations', description: 'Quiet, lightweight power stations with enough capacity for overnight CPAP use', href: '/best/power-stations/for-cpap', count: 6, priceRange: '$299 – $999', features: ['500–1,500Wh', 'Quiet operation', 'DC mode', 'Compact'] },
+  { title: 'Carry-On Power Stations', description: 'TSA-approved power banks for travel and airline carry-on', href: '/best/power-stations/carry-on-power-stations', count: 3, priceRange: '$99 – $399', features: ['Under 100Wh', 'TSA compliant', 'Compact design', 'Fast charging'] },
+];
+```
+
+- [ ] **Update hero tag line count**
+
+Change `'19+ Models Tested'` → `'33+ Models Tested'`
+
+- [ ] **Also add compare links to hub sidebar**
+
+Add to the `<aside>`:
+```tsx
+<div className="rounded-xl border border-neutral-200 bg-white p-4">
+  <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-primary">Compare Models</h3>
+  <ul className="space-y-2 text-sm">
+    <li><Link href="/best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000" className="text-neutral-600 hover:text-primary text-xs">EcoFlow Delta 3 Plus vs Anker C1000 →</Link></li>
+    <li><Link href="/best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2" className="text-neutral-600 hover:text-primary text-xs">Bluetti Elite 200 V2 vs Anker C2000 →</Link></li>
+    <li><Link href="/best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10" className="text-neutral-600 hover:text-primary text-xs">EcoFlow Delta Pro Ultra X vs Anker E10 →</Link></li>
+  </ul>
+</div>
+```
+
+- [ ] **Run type-check + build**
+
+```bash
+npm run type-check && npm run build 2>&1 | tail -20
+```
+
+Expected: clean type-check, build succeeds, hub page renders.
+
+- [ ] **Commit**
+
+```bash
+git add app/best/power-stations/page.tsx
+git commit -m "feat(hub): wire PowerStationQuiz and update category grid to 11 categories"
+```
+
+---
+
+## Task 10: Final verification
+
+- [ ] **Full build — confirm all routes**
+
+```bash
+npm run build 2>&1 | grep "power-station"
+```
+
+Expected output includes all of:
+```
+○ /best/power-stations
+○ /best/power-stations/rv-power-stations
+○ /best/power-stations/solar-generators
+○ /best/power-stations/under-500
+○ /best/power-stations/under-1000
+○ /best/power-stations/for-cpap
+○ /best/power-stations/240v-power-stations
+○ /best/power-stations/van-life
+○ /best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000
+○ /best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2
+○ /best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10
+```
+
+- [ ] **Confirm existing routes unchanged**
+
+```bash
+npm run build 2>&1 | grep -E "camping|carry-on|house-backup|portable-power"
+```
+
+Expected: all 4 existing routes still render as `○ (Static)`.
+
+- [ ] **Lint**
+
+```bash
+npm run lint
+```
+
+Expected: no errors.
+
+- [ ] **Final commit and push**
+
+```bash
+git add -A
+git commit -m "feat(power-stations): complete category expansion — 7 pages, 3 comparisons, finder quiz"
+git push
+```

--- a/docs/superpowers/specs/2025-05-06-power-station-categories-design.md
+++ b/docs/superpowers/specs/2025-05-06-power-station-categories-design.md
@@ -1,0 +1,206 @@
+# Power Station Category Expansion — Design Spec
+
+**Date:** 2025-05-06  
+**Status:** Approved  
+**Scope:** 7 new category pages + 3 comparison pages + 1 finder quiz
+
+---
+
+## Context
+
+ProductLabR has 33 power station reviews but only 4 category landing pages organized by spec (capacity/portability). Research shows top review sites drive significantly more traffic and engagement through use-case-first categorization. This spec covers expanding to use-case and price-intent category pages, adding model-vs-model comparison pages, and embedding a 3-question finder quiz on the power station hub.
+
+---
+
+## 1. Data Layer
+
+**File:** `lib/power-station-data.ts`
+
+Single source of truth for all power station category pages. Reads markdown frontmatter at build time via the existing `getPostMetadata()` + `gray-matter` pattern (already `React.cache`d).
+
+### Frontmatter additions required across existing reviews
+
+Two new fields added to each `posts/portable-power-stations/*.md` file:
+
+```yaml
+capacityWh: 1024          # numeric, for price/capacity filtering
+features:
+  - "30a-rv"              # has 30A RV outlet
+  - "solar"               # solar input ≥ 800W
+  - "240v"                # supports 240V output
+  - "cpap"                # suitable for CPAP (500–1500Wh, < 25 lbs)
+  - "van-life"            # compact + solar-capable (< 30 lbs, solar ≥ 400W)
+  - "solar-kit"           # sold as/commonly paired with solar panels
+```
+
+New reviews (added in this session) also need `category` field aligned:
+- `"large"` = 1,500–4,000Wh
+- `"home-backup"` = 4,000Wh+
+
+### Exported functions
+
+```ts
+getStationsByCategory(cat: string): PowerStationEntry[]
+getStationsUnderPrice(maxPrice: number): PowerStationEntry[]
+getStationsByFeature(feature: string): PowerStationEntry[]
+getStationsBySlugs(slugs: string[]): PowerStationEntry[]   // comparison pages
+getQuickPicks(entries: PowerStationEntry[]): PowerStationEntry[]  // top 3 by score
+```
+
+`PowerStationEntry` shape mirrors the existing `StationEntry` interface on category pages, extended with `capacityWh`, `features[]`, and `slug`.
+
+---
+
+## 2. Category Pages (7 new)
+
+All pages follow the identical structure as existing pages. New directories under `app/best/power-stations/`.
+
+### URL → filter mapping
+
+| Directory | Filter | Sidebar widget |
+|---|---|---|
+| `rv-power-stations/` | `features` includes `"30a-rv"` | 30A vs 50A explained |
+| `solar-generators/` | `features` includes `"solar"` or `"solar-kit"` | Solar sizing guide (static) |
+| `under-500/` | `price` ≤ 500 | What you get at each price band |
+| `under-1000/` | `price` ≤ 1000 | Value comparison chart |
+| `for-cpap/` | `features` includes `"cpap"` | CPAP runtime calculator (static) |
+| `240v-power-stations/` | `features` includes `"240v"` | 240V use case guide |
+| `van-life/` | `features` includes `"van-life"` | Van power budget guide |
+
+### Page structure (each)
+
+1. `Breadcrumb` — Home → Best Of → Power Stations → [Category]
+2. Hero banner — gradient, h1, description, 3 tag pills
+3. `QuickPicks` — top 3 by score from filtered set
+4. Ranked list — `RankedProductCard` × N, `AdBanner` injected after rank 3
+5. Buying guide / methodology section — unique prose per category
+6. Sidebar — Jump-to links + category-specific widget + `Newsletter`
+
+### Metadata
+Each page exports `metadata` with a keyword-optimised title and description targeting the primary search intent for that category.
+
+---
+
+## 3. Comparison Pages (3)
+
+**Base URL:** `/best/power-stations/compare/[slug-a]-vs-[slug-b]`
+
+### Initial pages
+1. `ecoflow-delta-3-plus-vs-anker-solix-c1000`
+2. `bluetti-elite-200-v2-vs-anker-solix-c2000-gen2`
+3. `ecoflow-delta-pro-ultra-x-vs-anker-solix-e10`
+
+### New component: `ComparisonCard`
+
+**File:** `components/ComparisonCard.tsx`
+
+Side-by-side layout:
+- Top row: product name, image, score, price, badge (winner/runner-up)
+- Spec table: capacity, inverter, solar input, weight, efficiency, price — winning value highlighted green per row
+- Pros/cons columns side by side
+- Verdict section: clear winner declaration + "who should buy which" paragraph
+
+Data sourced from `getStationsBySlugs([slugA, slugB])` — no hardcoded spec data beyond slug pairs.
+
+### Page structure (each)
+1. `Breadcrumb` — Home → Best Of → Power Stations → Compare → [title]
+2. `<title>` tag: "[Product A] vs [Product B]: Which Should You Buy? (2025)"
+3. `ComparisonCard`
+4. "Also compare" sidebar: links to the other 2 comparison pages
+5. `Newsletter`
+
+---
+
+## 4. Finder Quiz
+
+**Location:** Inline on `app/best/power-stations/page.tsx`, between hero and category grid.
+
+**Component:** `components/PowerStationQuiz.tsx` — `'use client'`
+
+### Questions
+
+1. **Budget** — Under $500 / $500–$1,000 / $1,000–$2,000 / $2,000+
+2. **Primary use** — Camping & outdoors / Home backup / RV & van life / Off-grid solar
+3. **Solar needed?** — Yes, essential / Nice to have / No, grid only
+
+### Routing matrix
+
+| Budget | Use | Solar | Route |
+|---|---|---|---|
+| <$500 | any | any | `/best/power-stations/under-500` |
+| $500–$1k | camping | yes/maybe | `/best/power-stations/solar-generators` |
+| $500–$1k | camping | no | `/best/power-stations/camping-power-stations` |
+| $500–$1k | home | any | `/best/power-stations/under-1000` |
+| $500–$1k | rv/van | any | `/best/power-stations/van-life` |
+| $1k–$2k | rv/van | any | `/best/power-stations/rv-power-stations` |
+| $1k–$2k | home | yes | `/best/power-stations/solar-generators` |
+| $1k–$2k | home | no | `/best/power-stations/house-backup-power-stations` |
+| $1k–$2k | solar | any | `/best/power-stations/solar-generators` |
+| $2k+ | any | any | `/best/power-stations/house-backup-power-stations` |
+| any | any | yes (essential) | `/best/power-stations/solar-generators` |
+
+### UI behaviour
+- Card-based answers with icons, single-select per question
+- Progress indicator (Step 1 of 3 etc.)
+- "Find my power station →" button activates only after all 3 answered
+- `useRouter().push()` on submit — no page reload
+- No external state, no API calls
+
+---
+
+## 5. Files Changed / Created
+
+### New files
+- `lib/power-station-data.ts`
+- `components/ComparisonCard.tsx`
+- `components/PowerStationQuiz.tsx`
+- `app/best/power-stations/rv-power-stations/page.tsx`
+- `app/best/power-stations/solar-generators/page.tsx`
+- `app/best/power-stations/under-500/page.tsx`
+- `app/best/power-stations/under-1000/page.tsx`
+- `app/best/power-stations/for-cpap/page.tsx`
+- `app/best/power-stations/240v-power-stations/page.tsx`
+- `app/best/power-stations/van-life/page.tsx`
+- `app/best/power-stations/compare/ecoflow-delta-3-plus-vs-anker-solix-c1000/page.tsx`
+- `app/best/power-stations/compare/bluetti-elite-200-v2-vs-anker-solix-c2000-gen2/page.tsx`
+- `app/best/power-stations/compare/ecoflow-delta-pro-ultra-x-vs-anker-solix-e10/page.tsx`
+
+### Modified files
+- `app/best/power-stations/page.tsx` — add `PowerStationQuiz` component
+- `posts/portable-power-stations/*.md` — add `capacityWh` and `features[]` to all 33 reviews
+
+### Unchanged
+- All existing category pages (`camping`, `carry-on`, `house-backup`, `portable`)
+- All existing components
+- Routing structure for existing URLs (no breaking changes)
+
+---
+
+## 6. Review Content Length Standard
+
+All new review markdown files must match the depth of pre-existing reviews. The benchmark is `ecoflow_delta_3_plus.md` at ~236 lines.
+
+**Minimum structure per review:**
+- Frontmatter (specs, pros, cons, ratings) — ~40 lines
+- Introduction — 2–3 paragraphs establishing the product's market position
+- Unboxing & First Impressions — 1–2 paragraphs
+- 4–6 feature/performance sections — each with an H2 + 2–3 paragraphs of depth (real-world context, not just spec restatement)
+- Competitive Analysis — compare against 2–3 direct rivals with specific trade-offs
+- Who It's For section — explicit ✅ / ❌ bullet lists
+- Final Verdict — 1–2 paragraphs + buy/don't-buy bullets
+- FAQ — 3–5 questions (optional but preferred for SEO)
+
+**Target:** 200–250 lines per file. Reviews under 150 lines must be expanded before publishing.
+
+This applies to all reviews written as part of implementation — both the 33 existing reviews that need `capacityWh`/`features[]` added, and any new reviews written to fill category gaps.
+
+---
+
+## 7. Verification
+
+1. `npm run build` — all 11 new routes appear in build output, no TypeScript errors
+2. Each category page shows ≥ 3 ranked products pulled from markdown
+3. Quiz routes correctly for all 11 routing matrix combinations
+4. Comparison pages render spec table with green winner highlights
+5. No existing URLs broken (check `camping`, `carry-on`, `house-backup`, `portable`)
+6. `npm run lint` — clean


### PR DESCRIPTION
## Summary
Adds a docs/ tree that documents the entire codebase from four audience perspectives (PM, developer, designer, content editor) plus reference material, so that anyone joining the project can find an entry point matched to their role and drill into deep technical references when needed.

## Details
- **Index & shared context**
  - `docs/README.md` — landing page with an audience selector and a pointer to existing root-level operational docs (`PRODUCTION.md`, `ADSENSE_SETUP.md`, `BEST_SECTION_README.md`).
  - `docs/overview.md` — one-diagram product overview, tech stack table, monetization model, in-flight roadmap.
- **Audience guides (explanation)**
  - `docs/for-product-managers.md` — information architecture, content inventory by category, ranking model, monetization slots, success metrics, hosting constraints, how to request a new vertical.
  - `docs/for-developers.md` — quick start, repo tour, routing conventions, data layer contract, content/frontmatter shape, styling, conventions from `copilot-instructions.md`, build/deploy, gotchas table, branch/PR conventions, worked example of adding a sub-category page.
  - `docs/for-designers.md` — color tokens (CSS variables), typography (Playfair Display + Inter), spacing/layout, radii/shadows, component anatomy with ASCII mockups, motion language, imagery rules, accessibility requirements.
  - `docs/for-content-editors.md` — how to write a review, minimum-viable frontmatter, category-specific extras (power-station `capacityWh` / `features`), body structure recommendations, image rules, affiliate-link rules, publishing checklist, common mistakes.
- **Architecture deep dive**
  - `docs/architecture.md` — rendering model (build-time static), data flow diagram, rationale for RSC, two-tier data layer, markdown pipeline, styling architecture, image handling, monetization wiring, security posture, CI pipeline, performance targets, known constraints/trade-offs.
- **Reference**
  - `docs/reference/content-schema.md` — full frontmatter schema (required/optional/category-specific), nested shapes (`specs`, `retailerLinks`, `ratingBreakdown`), slug rules, worked example.
  - `docs/reference/components.md` — component catalog grouped by layout, product surfaces, article components, interactive, badges, utility, ads — with key props and a "pick the right component" selection guide.
  - `docs/reference/routes.md` — every route in the app (home, articles, all `/best/*` hubs and sub-categories, comparison pages), how dynamic routes are pre-compiled, instructions for adding new routes.
- **Active work**
  - Tracks the previously-untracked `docs/superpowers/specs/2025-05-06-power-station-categories-design.md` and `docs/superpowers/plans/2025-05-06-power-station-category-expansion.md` so the docs that reference them are not pointing at untracked files.

## Testing Done
- [ ] Verify all relative links between docs files resolve (manual click-through on GitHub PR preview).
- [ ] Confirm links from `docs/README.md` to root-level operational docs (`../PRODUCTION.md`, `../ADSENSE_SETUP.md`, `../BEST_SECTION_README.md`) resolve.
- [ ] Skim each audience guide and confirm code/file references match the current repo state.
- [ ] Confirm reference docs (content schema, components, routes) match the actual implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)