### PR TITLE
feat(ui): MD3 alignment — type scale, image-forward cards, mobile nav, trust bar

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "extends": ["next/core-web-vitals", "prettier"],
   "plugins": ["@typescript-eslint", "unused-imports"],
   "rules": {
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
     "@typescript-eslint/no-explicit-any": "error",
     "unused-imports/no-unused-imports": "error",
     "unused-imports/no-unused-vars": [

--- a/app/best/power-stations/240v-power-stations/page.tsx
+++ b/app/best/power-stations/240v-power-stations/page.tsx
@@ -58,7 +58,6 @@ export default function TwoFortyVPowerStationsPage() {
                       image={station.image}
                       summary={station.subtitle}
                       score={station.score}
-                      price={station.price}
                       specs={station.specs}
                     />
                     {i === 2 && (

--- a/app/best/power-stations/for-cpap/page.tsx
+++ b/app/best/power-stations/for-cpap/page.tsx
@@ -58,7 +58,6 @@ export default function ForCpapPage() {
                       image={station.image}
                       summary={station.subtitle}
                       score={station.score}
-                      price={station.price}
                       specs={station.specs}
                     />
                     {i === 2 && (

--- a/app/best/power-stations/rv-power-stations/page.tsx
+++ b/app/best/power-stations/rv-power-stations/page.tsx
@@ -58,7 +58,6 @@ export default function RvPowerStationsPage() {
                       image={station.image}
                       summary={station.subtitle}
                       score={station.score}
-                      price={station.price}
                       specs={station.specs}
                     />
                     {i === 2 && (

--- a/app/best/power-stations/solar-generators/page.tsx
+++ b/app/best/power-stations/solar-generators/page.tsx
@@ -60,7 +60,6 @@ export default function SolarGeneratorsPage() {
                       image={station.image}
                       summary={station.subtitle}
                       score={station.score}
-                      price={station.price}
                       specs={station.specs}
                     />
                     {i === 2 && (

--- a/app/best/power-stations/under-1000/page.tsx
+++ b/app/best/power-stations/under-1000/page.tsx
@@ -58,7 +58,6 @@ export default function Under1000Page() {
                       image={station.image}
                       summary={station.subtitle}
                       score={station.score}
-                      price={station.price}
                       specs={station.specs}
                     />
                     {i === 2 && (

--- a/app/best/power-stations/under-500/page.tsx
+++ b/app/best/power-stations/under-500/page.tsx
@@ -58,7 +58,6 @@ export default function Under500Page() {
                       image={station.image}
                       summary={station.subtitle}
                       score={station.score}
-                      price={station.price}
                       specs={station.specs}
                     />
                     {i === 2 && (

--- a/app/best/power-stations/van-life/page.tsx
+++ b/app/best/power-stations/van-life/page.tsx
@@ -58,7 +58,6 @@ export default function VanLifePage() {
                       image={station.image}
                       summary={station.subtitle}
                       score={station.score}
-                      price={station.price}
                       specs={station.specs}
                     />
                     {i === 2 && (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,8 @@ import { Inter, Playfair_Display } from 'next/font/google';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
+import { TrustBar } from '@/components/TrustBar';
+import { MobileBottomNav } from '@/components/MobileBottomNav';
 import { ADSENSE_CONFIG } from '@/lib/adsense-config';
 import { SITE_URL } from '@/lib/site-url';
 import getPostMetadata from '@/components/getPostMetadata';
@@ -102,10 +104,12 @@ export default function RootLayout({
           strategy="afterInteractive"
         />
         <Header posts={posts} />
-        <main className="mx-auto max-w-[1280px] px-4 sm:px-6">
+        <TrustBar />
+        <main className="mx-auto max-w-[1280px] px-4 pb-16 sm:px-6 md:pb-0">
           {children}
         </main>
         <Footer />
+        <MobileBottomNav />
         {gaId && <GoogleAnalytics gaId={gaId} />}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -84,7 +84,7 @@ export default function Home() {
         <div>
           {/* Latest Reviews */}
           <SectionLabel>Latest Reviews</SectionLabel>
-          <div className="space-y-1">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
             {recentPosts.map((post) => (
               <ReviewCard key={post.slug} post={post} />
             ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -160,10 +160,10 @@ export default function Home() {
                   <Link
                     key={cat}
                     href={`/best/${cat}`}
-                    className="flex items-center justify-between rounded-md bg-primary-lightest/50 px-3 py-2 text-[13px] text-neutral-500 hover:bg-primary-lightest"
+                    className="flex items-center justify-between rounded-md bg-primary-lightest/50 px-3 py-2 text-sm text-neutral-500 hover:bg-primary-lightest"
                   >
                     {cat.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
-                    <span className="rounded-full bg-primary px-1.5 text-[10px] text-white">
+                    <span className="rounded-full bg-primary px-1.5 type-label text-white">
                       {catPosts.length}
                     </span>
                   </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,57 +24,48 @@ export default function Home() {
   const categories = getAllCategories();
 
   const featuredScore = featured?.ratingBreakdown
-    ? featured.ratingBreakdown.metrics.reduce((sum, m) => sum + m.score, 0) /
-      featured.ratingBreakdown.metrics.length / 10
+    ? featured.ratingBreakdown.metrics.length > 0
+      ? featured.ratingBreakdown.metrics.reduce((sum, m) => sum + m.score, 0) /
+        featured.ratingBreakdown.metrics.length
+      : null
     : featured?.rating
-      ? (featured.rating * 2) / 10
+      ? featured.rating * 2
       : null;
 
   return (
     <>
       {/* Hero — Editor's Pick */}
-      <section className="-mx-4 bg-gradient-to-b from-primary-lightest via-blue-50 to-neutral-50 px-4 py-8 sm:-mx-6 sm:px-6">
-        <div className="flex items-center gap-1.5 text-xs font-bold uppercase tracking-[0.15em] text-primary">
-          <span className="h-1.5 w-1.5 rounded-full bg-accent" />
-          Editor&apos;s Pick
+      <section className="-mx-4 bg-gradient-to-b from-primary-lightest via-blue-50 to-neutral-50 px-4 py-10 sm:-mx-6 sm:px-6">
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-accent" />
+          <span className="type-label text-accent">Editor&apos;s Pick</span>
         </div>
+
         {featured && (
-          <div className="mt-4 grid items-center gap-6 md:grid-cols-2">
+          <div className="mt-5 grid items-center gap-6 md:grid-cols-2">
             <div>
-              <h1 className="text-2xl font-bold leading-tight text-neutral-900 md:text-[26px]">
-                {featured.title}
-              </h1>
+              <h1 className="type-display text-neutral-900">{featured.title}</h1>
               {featured.subtitle && (
-                <p className="mt-2 text-sm leading-relaxed text-neutral-500">
-                  {featured.subtitle}
-                </p>
+                <p className="type-body mt-3 max-w-md text-neutral-500">{featured.subtitle}</p>
               )}
-              <div className="mt-3 flex flex-wrap items-center gap-3">
-                {featuredScore && <ScoreBadge score={featuredScore} showLabel />}
-                {featured.price && (
-                  <span className="text-base font-bold text-neutral-900">{featured.price}</span>
-                )}
-              </div>
-              <div className="mt-4 flex flex-wrap items-center gap-2">
+
+              {featuredScore !== null && (
+                <div className="mt-4 flex items-center gap-3">
+                  <ScoreBadge score={featuredScore} size="lg" showLabel />
+                </div>
+              )}
+
+              <div className="mt-5">
                 <Link
                   href={`/articles/${featured.slug}`}
-                  className="bg-accent text-white px-5 py-2.5 rounded-md font-semibold text-sm hover:opacity-90 transition-opacity"
+                  className="inline-block rounded-md bg-accent px-6 py-3 type-title text-white transition-opacity hover:opacity-90"
                 >
-                  Read Full Review
+                  Read Full Review →
                 </Link>
-                {featured.retailerLinks && Object.keys(featured.retailerLinks).length > 0 && (
-                  <a
-                    href={Object.values(featured.retailerLinks)[0]}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="border border-neutral-300 text-neutral-700 px-5 py-2.5 rounded-md font-semibold text-sm hover:bg-neutral-50 transition-colors"
-                  >
-                    Buy Now
-                  </a>
-                )}
               </div>
             </div>
-            <div className="relative h-44 overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-featured md:h-52">
+
+            <div className="relative h-52 overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-featured md:h-64">
               <OptimizedImage
                 src={featured.image || featured.productImage || '/images/item.png'}
                 alt={featured.title}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,10 +11,10 @@ import { ADSENSE_CONFIG } from '@/lib/adsense-config';
 import { getAllCategories, getPostsByCategory } from '@/lib/Posts';
 
 const bestOfGuides = [
-  { title: 'Best Hybrid Cameras', href: '/best/cameras/hybrid-cameras', count: 8, updated: 'Mar 2026', color: 'border-primary' },
-  { title: 'Best Portable Power Stations', href: '/best/power-stations/portable-power-stations', count: 12, updated: 'Mar 2026', color: 'border-accent' },
-  { title: 'Best Camping Power Stations', href: '/best/power-stations/camping-power-stations', count: 6, updated: 'Feb 2026', color: 'border-primary' },
-  { title: 'Best Pro Photo Cameras', href: '/best/cameras/professional-photo-cameras', count: 5, updated: 'Mar 2026', color: 'border-accent' },
+  { title: 'Best Hybrid Cameras',          href: '/best/cameras/hybrid-cameras',                count: 8,  icon: '📷', theme: 'blue',   updated: 'Mar 2026' },
+  { title: 'Best Portable Power Stations', href: '/best/power-stations/portable-power-stations', count: 12, icon: '⚡', theme: 'orange', updated: 'Mar 2026' },
+  { title: 'Best Camping Power Stations',  href: '/best/power-stations/camping-power-stations',  count: 6,  icon: '🏕️', theme: 'green',  updated: 'Feb 2026' },
+  { title: 'Best Pro Photo Cameras',       href: '/best/cameras/professional-photo-cameras',     count: 5,  icon: '🎞️', theme: 'blue',   updated: 'Mar 2026' },
 ];
 
 export default function Home() {
@@ -111,23 +111,37 @@ export default function Home() {
           {/* Best Of Guides */}
           <SectionLabel>Best Of Guides</SectionLabel>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            {bestOfGuides.map((guide) => (
-              <Link
-                key={guide.href}
-                href={guide.href}
-                className={`rounded-lg border border-neutral-200 border-l-[3px] ${guide.color} bg-white p-4 transition-shadow hover:shadow-card-hover`}
-              >
-                <span className={`text-[11px] font-medium ${guide.color === 'border-accent' ? 'text-accent' : 'text-primary'}`}>
-                  Updated {guide.updated}
-                </span>
-                <h3 className="mt-1 text-sm font-semibold text-neutral-900">
-                  {guide.title}
-                </h3>
-                <span className="mt-1 text-xs text-neutral-400">
-                  {guide.count} products tested →
-                </span>
-              </Link>
-            ))}
+            {bestOfGuides.map((guide) => {
+              const tintClass =
+                guide.theme === 'orange' ? 'bg-amber-50'
+                : guide.theme === 'green' ? 'bg-green-50'
+                : 'bg-primary-lightest';
+              const badgeClass =
+                guide.theme === 'orange' ? 'bg-amber-50 text-accent'
+                : guide.theme === 'green' ? 'bg-green-50 text-success'
+                : 'bg-primary-lightest text-primary';
+
+              return (
+                <Link
+                  key={guide.href}
+                  href={guide.href}
+                  className="state-layer relative overflow-hidden rounded-xl border border-neutral-200 bg-white p-4 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-card-hover"
+                >
+                  {/* Tinted corner accent */}
+                  <div
+                    className={`pointer-events-none absolute right-0 top-0 h-14 w-14 rounded-bl-[60px] rounded-tr-xl ${tintClass} opacity-70`}
+                  />
+                  <span className="text-2xl">{guide.icon}</span>
+                  <h3 className="type-title mt-2 text-neutral-900">{guide.title}</h3>
+                  <div className="mt-2 flex items-center justify-between">
+                    <span className="type-label text-neutral-400">Updated {guide.updated}</span>
+                    <span className={`type-label rounded-full px-2 py-0.5 ${badgeClass}`}>
+                      {guide.count} tested
+                    </span>
+                  </div>
+                </Link>
+              );
+            })}
           </div>
         </div>
 

--- a/components/CategoryDropdown.tsx
+++ b/components/CategoryDropdown.tsx
@@ -7,7 +7,7 @@ import { ChevronDown } from 'lucide-react';
 interface CategoryItem {
   name: string;
   href: string;
-  count: number;
+  count?: number;
 }
 
 interface CategoryDropdownProps {
@@ -39,7 +39,9 @@ export function CategoryDropdown({ categories }: CategoryDropdownProps) {
           {categories.map((cat) => (
             <Link key={cat.href} href={cat.href} onClick={() => setIsOpen(false)} className="flex items-center justify-between px-4 py-2 text-sm text-neutral-700 hover:bg-primary-lightest">
               {cat.name}
-              <span className="rounded-full bg-primary px-1.5 text-[10px] text-white">{cat.count}</span>
+              {cat.count !== undefined && (
+                <span className="rounded-full bg-primary px-1.5 text-[10px] text-white">{cat.count}</span>
+              )}
             </Link>
           ))}
         </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Menu, X } from 'lucide-react';
 import { SearchBar } from './SearchBar';
 import { CategoryDropdown } from './CategoryDropdown';
+import { NAV_CATEGORIES } from '@/lib/nav-categories';
 
 interface SearchPost {
   title: string;
@@ -17,68 +16,42 @@ interface HeaderProps {
   posts?: SearchPost[];
 }
 
-const navLinks = [
-  { label: 'Laptops', href: '/best/laptops' },
-  { label: 'TVs', href: '/best/tvs' },
+const NAV_LINKS = [
+  { label: 'Laptops',    href: '/best/laptops'   },
+  { label: 'TVs',        href: '/best/tvs'        },
   { label: 'Headphones', href: '/best/headphones' },
 ];
 
-const categories = [
-  { name: 'Laptops', href: '/best/laptops', count: 0 },
-  { name: 'TVs', href: '/best/tvs', count: 0 },
-  { name: 'Headphones & Earbuds', href: '/best/headphones', count: 0 },
-  { name: 'Smartphones', href: '/best/smartphones', count: 0 },
-  { name: 'Monitors', href: '/best/monitors', count: 0 },
-  { name: 'Smart Home', href: '/best/smart-home', count: 0 },
-  { name: 'Wearables', href: '/best/wearables', count: 0 },
-  { name: 'Gaming', href: '/best/gaming', count: 0 },
-  { name: 'Cameras', href: '/best/cameras', count: 15 },
-  { name: 'Power Stations', href: '/best/power-stations', count: 19 },
-];
-
 export function Header({ posts = [] }: HeaderProps) {
-  const [mobileOpen, setMobileOpen] = useState(false);
   const pathname = usePathname();
 
   return (
     <header className="sticky top-0 z-50 bg-gradient-to-r from-primary to-primary-dark">
       <div className="mx-auto flex max-w-content items-center justify-between px-4 py-3 sm:px-6">
         <div className="flex items-center gap-6">
-          <Link href="/" className="text-base font-bold tracking-wide text-white">PRODUCT LAB</Link>
+          <Link href="/" className="text-base font-bold tracking-wide text-white">
+            PRODUCT LAB
+          </Link>
           <nav className="hidden items-center gap-4 md:flex">
-            {navLinks.map((link) => (
-              <Link key={link.href} href={link.href} className={`text-[13px] text-white/85 hover:text-white ${pathname.startsWith(link.href) ? 'border-b-2 border-white pb-0.5' : ''}`}>
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`text-[13px] text-white/85 hover:text-white ${
+                  pathname.startsWith(link.href) ? 'border-b-2 border-white pb-0.5' : ''
+                }`}
+              >
                 {link.label}
               </Link>
             ))}
-            <CategoryDropdown categories={categories} />
+            <CategoryDropdown categories={NAV_CATEGORIES} />
           </nav>
         </div>
+
         <div className="hidden md:block">
           <SearchBar posts={posts} variant="header" />
         </div>
-        <button className="p-1 text-white md:hidden" onClick={() => setMobileOpen(!mobileOpen)} aria-label={mobileOpen ? 'Close menu' : 'Open menu'}>
-          {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
-        </button>
       </div>
-      {mobileOpen && (
-        <div className="border-t border-white/10 bg-primary-dark md:hidden">
-          <SearchBar posts={posts} variant="mobile" />
-          <nav className="flex flex-col">
-            {navLinks.map((link) => (
-              <Link key={link.href} href={link.href} onClick={() => setMobileOpen(false)} className="border-b border-white/10 px-4 py-3 text-sm text-white/90 hover:bg-white/5">
-                {link.label}
-              </Link>
-            ))}
-            {categories.map((cat) => (
-              <Link key={cat.href} href={cat.href} onClick={() => setMobileOpen(false)} className="flex items-center justify-between border-b border-white/10 px-4 py-3 text-sm text-white/75">
-                {cat.name}
-                <span className="text-xs text-white/50">{cat.count}</span>
-              </Link>
-            ))}
-          </nav>
-        </div>
-      )}
     </header>
   );
 }

--- a/components/MobileBottomNav.tsx
+++ b/components/MobileBottomNav.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { NAV_CATEGORIES } from '@/lib/nav-categories';
+
+const NAV_ITEMS = [
+  { label: 'Home',    href: '/',     icon: '🏠' },
+  { label: 'Best Of', href: '/best', icon: '🏆' },
+  { label: 'Search',  href: null,    icon: '🔍' },
+] as const;
+
+export function MobileBottomNav() {
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const pathname = usePathname();
+
+  const isActive = (href: string | null) => href !== null && pathname === href;
+
+  return (
+    <>
+      {/* Slide-up category sheet */}
+      {sheetOpen && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-40 bg-black/30 md:hidden"
+            onClick={() => setSheetOpen(false)}
+            aria-hidden="true"
+          />
+
+          {/* Sheet */}
+          <div className="fixed inset-x-0 bottom-16 z-50 max-h-[60vh] overflow-y-auto rounded-t-2xl bg-white pb-4 shadow-xl md:hidden">
+            <div className="sticky top-0 bg-white px-4 pb-2 pt-3">
+              <div className="mx-auto h-1 w-8 rounded-full bg-neutral-300" />
+              <p className="type-label mt-2 text-neutral-500">All Categories</p>
+            </div>
+            <div className="grid grid-cols-2 gap-2 px-4">
+              {NAV_CATEGORIES.map((cat) => (
+                <Link
+                  key={cat.href}
+                  href={cat.href}
+                  onClick={() => setSheetOpen(false)}
+                  className="flex items-center gap-2 rounded-lg bg-neutral-50 px-3 py-3 transition-colors hover:bg-primary-lightest"
+                >
+                  <span className="text-lg">{cat.icon}</span>
+                  <span className="type-title text-neutral-800">{cat.name}</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Bottom nav bar */}
+      <nav className="fixed inset-x-0 bottom-0 z-50 grid grid-cols-4 border-t border-neutral-200 bg-white md:hidden">
+        {NAV_ITEMS.map((item) => {
+          const active = isActive(item.href);
+          return (
+            <Link
+              key={item.label}
+              href={item.href ?? '#'}
+              className="flex flex-col items-center gap-0.5 py-2"
+              aria-current={active ? 'page' : undefined}
+            >
+              <span className="text-xl leading-none">{item.icon}</span>
+              <span className={`type-label ${active ? 'text-primary' : 'text-neutral-400'}`}>
+                {item.label}
+              </span>
+              {active && <span className="h-0.5 w-4 rounded-full bg-primary" />}
+            </Link>
+          );
+        })}
+
+        {/* Categories — opens sheet, not a link */}
+        <button
+          type="button"
+          onClick={() => setSheetOpen((prev) => !prev)}
+          className="flex flex-col items-center gap-0.5 py-2"
+          aria-expanded={sheetOpen}
+          aria-label="Open categories"
+        >
+          <span className="text-xl leading-none">☰</span>
+          <span className={`type-label ${sheetOpen ? 'text-primary' : 'text-neutral-400'}`}>
+            Categories
+          </span>
+          {sheetOpen && <span className="h-0.5 w-4 rounded-full bg-primary" />}
+        </button>
+      </nav>
+    </>
+  );
+}

--- a/components/MobileBottomNav.tsx
+++ b/components/MobileBottomNav.tsx
@@ -8,7 +8,6 @@ import { NAV_CATEGORIES } from '@/lib/nav-categories';
 const NAV_ITEMS = [
   { label: 'Home',    href: '/',     icon: '🏠' },
   { label: 'Best Of', href: '/best', icon: '🏆' },
-  { label: 'Search',  href: null,    icon: '🔍' },
 ] as const;
 
 export function MobileBottomNav() {
@@ -30,7 +29,12 @@ export function MobileBottomNav() {
           />
 
           {/* Sheet */}
-          <div className="fixed inset-x-0 bottom-16 z-50 max-h-[60vh] overflow-y-auto rounded-t-2xl bg-white pb-4 shadow-xl md:hidden">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="All Categories"
+            className="fixed inset-x-0 bottom-16 z-50 max-h-[60vh] overflow-y-auto rounded-t-2xl bg-white pb-4 shadow-xl md:hidden"
+          >
             <div className="sticky top-0 bg-white px-4 pb-2 pt-3">
               <div className="mx-auto h-1 w-8 rounded-full bg-neutral-300" />
               <p className="type-label mt-2 text-neutral-500">All Categories</p>
@@ -71,6 +75,17 @@ export function MobileBottomNav() {
             </Link>
           );
         })}
+
+        {/* Search — placeholder for future search feature */}
+        <button
+          type="button"
+          className="flex flex-col items-center gap-0.5 py-2"
+          aria-label="Search"
+          disabled
+        >
+          <span className="text-xl leading-none opacity-40">🔍</span>
+          <span className="type-label text-neutral-300">Search</span>
+        </button>
 
         {/* Categories — opens sheet, not a link */}
         <button

--- a/components/RankedProductCard.tsx
+++ b/components/RankedProductCard.tsx
@@ -17,7 +17,7 @@ interface RankedProductCardProps {
 }
 
 export function RankedProductCard({
-  rank, name, href, image, summary, score, badge, buyUrl, specs,
+  rank, name, href, image, summary, score, badge, buyUrl: _buyUrl, specs,
 }: RankedProductCardProps) {
   const isTopRanked = rank === 1;
 

--- a/components/RankedProductCard.tsx
+++ b/components/RankedProductCard.tsx
@@ -1,6 +1,5 @@
+// components/RankedProductCard.tsx
 import Link from 'next/link';
-import { ExternalLink } from 'lucide-react';
-import { isSafeUrl } from '@/lib/utils';
 import { OptimizedImage } from './OptimizedImage';
 import { ScoreBadge } from './ScoreBadge';
 import { AwardBadge } from './AwardBadge';
@@ -12,66 +11,59 @@ interface RankedProductCardProps {
   image: string;
   summary: string;
   score: number;
-  price: string;
   badge?: 'best-overall' | 'best-value' | 'budget-pick';
-  buyUrl?: string;
-  buyLabel?: string;
+  buyUrl?: string;  // retained for future "Check Price" wiring — not rendered yet
   specs?: Record<string, string>;
 }
 
 export function RankedProductCard({
-  rank, name, href, image, summary, score, price, badge, buyUrl, buyLabel = 'Buy at Amazon', specs,
+  rank, name, href, image, summary, score, badge, buyUrl, specs,
 }: RankedProductCardProps) {
+  const isTopRanked = rank === 1;
+
   return (
     <div
-      className={`
-        group relative rounded-xl border border-neutral-200 p-5 cursor-pointer
-        transition-all duration-200 ease-out
-        hover:-translate-y-1 hover:shadow-xl hover:shadow-neutral-200/80
-        ${rank === 1 ? 'border-l-4 border-l-accent bg-amber-50/30' : 'bg-white'}
-      `}
+      className={[
+        'group relative rounded-xl border border-neutral-200 p-5 cursor-pointer',
+        'transition-all duration-200 ease-out',
+        'hover:-translate-y-1 hover:shadow-xl hover:shadow-neutral-200/80',
+        isTopRanked
+          ? 'state-layer-light border-l-4 border-l-accent bg-amber-50/30'
+          : 'state-layer bg-white',
+      ].join(' ')}
     >
-      {/* Stretched link — makes the whole card clickable */}
+      {/* Stretched link — whole card clickable */}
       <Link href={href} className="absolute inset-0 z-0 rounded-xl" aria-label={`Read ${name} review`} />
 
       <div className="flex flex-col gap-5 sm:flex-row">
         <div className="relative h-36 w-full flex-shrink-0 overflow-hidden rounded-lg bg-gradient-to-br from-primary-lightest to-primary-light/30 sm:w-44">
           <OptimizedImage src={image} alt={name} fill sizes="180px" className="object-contain p-2" />
         </div>
+
         <div className="flex-1">
           <div className="flex items-center gap-2">
             {badge && <AwardBadge type={badge} />}
-            <span className="text-[11px] text-neutral-400">#{rank}</span>
+            <span className="type-label text-neutral-400">#{rank}</span>
           </div>
-          <h3 className="mt-1 text-lg font-bold text-neutral-900">{name}</h3>
-          <p className="mt-1.5 text-[13px] leading-relaxed text-neutral-500">{summary}</p>
-          <div className="mt-2.5 flex items-center gap-3">
-            <ScoreBadge score={score} showLabel />
-            <span className="text-base font-bold text-neutral-900">{price}</span>
-            <span className="text-xs font-medium text-green-600">In Stock</span>
-          </div>
-          <div className="mt-2.5 flex gap-2">
-            {buyUrl && isSafeUrl(buyUrl) && (
-              <a
-                href={buyUrl}
-                target="_blank"
-                rel="noopener noreferrer nofollow"
-                onClick={(e) => e.stopPropagation()}
-                className="relative z-10 inline-flex items-center gap-1 rounded-md bg-accent px-5 py-2 text-sm font-semibold text-white transition-transform hover:scale-105 hover:bg-accent/90"
-              >
-                {buyLabel}<ExternalLink className="h-3 w-3" />
-              </a>
-            )}
-            <span className="relative z-10 text-xs text-primary">
+
+          <h3 className="type-title mt-1 text-neutral-900">{name}</h3>
+          <p className="type-body mt-1.5 text-neutral-500">{summary}</p>
+
+          <div className="mt-3 flex items-center gap-3">
+            <ScoreBadge score={score} size="lg" showLabel />
+            <span className="relative z-10 type-label text-primary hover:text-primary-dark">
               Read Review →
             </span>
           </div>
         </div>
       </div>
+
       {specs && Object.keys(specs).length > 0 && (
-        <div className="mt-3.5 flex flex-wrap gap-4 border-t border-neutral-100 pt-3.5 text-xs">
+        <div className="mt-3.5 flex flex-wrap gap-4 border-t border-neutral-100 pt-3.5">
           {Object.entries(specs).slice(0, 5).map(([key, value]) => (
-            <span key={key} className="text-neutral-400">{key}: <strong className="text-neutral-700">{value}</strong></span>
+            <span key={key} className="type-label text-neutral-400">
+              {key}: <strong className="font-semibold text-neutral-700">{value}</strong>
+            </span>
           ))}
         </div>
       )}

--- a/components/ReviewCard.tsx
+++ b/components/ReviewCard.tsx
@@ -10,8 +10,10 @@ interface ReviewCardProps {
 
 export function ReviewCard({ post }: ReviewCardProps) {
   const score = post.ratingBreakdown
-    ? post.ratingBreakdown.metrics.reduce((sum, m) => sum + m.score, 0) /
-      post.ratingBreakdown.metrics.length
+    ? post.ratingBreakdown.metrics.length > 0
+      ? post.ratingBreakdown.metrics.reduce((sum, m) => sum + m.score, 0) /
+        post.ratingBreakdown.metrics.length
+      : null
     : post.rating
       ? post.rating * 2
       : null;

--- a/components/ReviewCard.tsx
+++ b/components/ReviewCard.tsx
@@ -1,3 +1,4 @@
+// components/ReviewCard.tsx
 import Link from 'next/link';
 import { OptimizedImage } from './OptimizedImage';
 import { ScoreBadge } from './ScoreBadge';
@@ -9,28 +10,41 @@ interface ReviewCardProps {
 
 export function ReviewCard({ post }: ReviewCardProps) {
   const score = post.ratingBreakdown
-    ? post.ratingBreakdown.metrics.reduce((sum, m) => sum + m.score, 0) / post.ratingBreakdown.metrics.length
-    : post.rating ? post.rating * 2 : null;
+    ? post.ratingBreakdown.metrics.reduce((sum, m) => sum + m.score, 0) /
+      post.ratingBreakdown.metrics.length
+    : post.rating
+      ? post.rating * 2
+      : null;
 
   return (
-    <Link href={`/articles/${post.slug}`} className="flex gap-4 rounded-lg p-3 transition-colors hover:bg-primary-lightest/50">
-      <div className="relative h-20 w-[120px] flex-shrink-0 overflow-hidden rounded-lg bg-gradient-to-br from-primary-lightest to-primary-light/30">
+    <Link
+      href={`/articles/${post.slug}`}
+      className="state-layer group flex flex-col overflow-hidden rounded-xl border border-neutral-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:shadow-card-hover"
+    >
+      <div className="relative aspect-[3/2] w-full overflow-hidden bg-gradient-to-br from-primary-lightest to-primary-light/30">
         <OptimizedImage
           src={post.image || post.productImage || '/images/item.png'}
           alt={post.title}
           fill
-          sizes="120px"
+          sizes="(max-width: 640px) 50vw, 33vw"
           className="object-cover"
         />
+        {score !== null && (
+          <div className="absolute right-2 top-2">
+            <ScoreBadge score={score} size="sm" />
+          </div>
+        )}
       </div>
-      <div className="min-w-0 flex-1">
-        {post.category && <span className="text-[11px] font-semibold text-primary">{post.category}</span>}
-        <h3 className="mt-0.5 line-clamp-2 text-[15px] font-semibold leading-snug text-neutral-900">{post.title}</h3>
-        {post.subtitle && <p className="mt-1 line-clamp-2 text-[13px] leading-relaxed text-neutral-500">{post.subtitle}</p>}
-        <div className="mt-1.5 flex items-center gap-2">
-          {score && <ScoreBadge score={score / 10} />}
-          <span className="text-[11px] text-neutral-400">{post.date}</span>
-        </div>
+
+      <div className="flex flex-1 flex-col p-3">
+        {post.category && (
+          <span className="type-label text-primary">{post.category}</span>
+        )}
+        <h3 className="type-title mt-1 line-clamp-2 text-neutral-900">{post.title}</h3>
+        {post.subtitle && (
+          <p className="type-body mt-1 line-clamp-2 text-neutral-500">{post.subtitle}</p>
+        )}
+        <span className="type-label mt-2 text-neutral-400">{post.date}</span>
       </div>
     </Link>
   );

--- a/components/ScoreBadge.tsx
+++ b/components/ScoreBadge.tsx
@@ -16,8 +16,8 @@ function getScoreLabel(score: number): string {
 }
 
 function getScoreBgClass(score: number): string {
-  if (score >= 9.0) return 'bg-green-600';
-  if (score >= 8.0) return 'bg-blue-600';
+  if (score >= 9.0) return 'bg-accent';     // was bg-green-600
+  if (score >= 8.0) return 'bg-primary';    // was bg-blue-600
   if (score >= 7.0) return 'bg-amber-500';
   return 'bg-neutral-500';
 }

--- a/components/TrustBar.tsx
+++ b/components/TrustBar.tsx
@@ -1,0 +1,24 @@
+import getPostMetadata from '@/components/getPostMetadata';
+
+export function TrustBar() {
+  const count = getPostMetadata().length;
+  const signals = [
+    `${count} products tested`,
+    'Real-world conditions',
+    'No sponsored reviews',
+    `Updated ${new Date().toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}`,
+  ];
+
+  return (
+    <div className="bg-primary-dark px-4 py-1.5 sm:px-6">
+      <div className="mx-auto flex max-w-content items-center gap-4 overflow-x-auto">
+        {signals.map((signal) => (
+          <span key={signal} className="type-label flex flex-shrink-0 items-center gap-1.5 text-white/85">
+            <span className="text-success">✓</span>
+            {signal}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/TrustBar.tsx
+++ b/components/TrustBar.tsx
@@ -1,20 +1,26 @@
 import getPostMetadata from '@/components/getPostMetadata';
 
 export function TrustBar() {
-  const count = getPostMetadata().length;
+  const posts = getPostMetadata();
+  const count = posts.length;
+
+  const latestDate = posts[0]?.date
+    ? new Date(posts[0].date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+    : null;
+
   const signals = [
     `${count} products tested`,
     'Real-world conditions',
     'No sponsored reviews',
-    `Updated ${new Date().toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}`,
+    ...(latestDate ? [`Reviewed through ${latestDate}`] : []),
   ];
 
   return (
-    <div className="bg-primary-dark px-4 py-1.5 sm:px-6">
+    <div className="bg-primary-dark px-4 py-1.5 sm:px-6" role="region" aria-label="Trust signals">
       <div className="mx-auto flex max-w-content items-center gap-4 overflow-x-auto">
         {signals.map((signal) => (
           <span key={signal} className="type-label flex flex-shrink-0 items-center gap-1.5 text-white/85">
-            <span className="text-success">✓</span>
+            <span className="text-success" aria-hidden="true">✓</span>
             {signal}
           </span>
         ))}

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,10 +35,14 @@ These live at the repo root because they were authored before this docs tree exi
 
 ## Active work
 
-In-flight specs and plans live under `docs/superpowers/`:
+Specs and plans live under `docs/superpowers/`. Completed work is kept for reference.
 
-- **Spec:** [Power Station Categories Design](./superpowers/specs/2025-05-06-power-station-categories-design.md)
-- **Plan:** [Power Station Category Expansion](./superpowers/plans/2025-05-06-power-station-category-expansion.md)
+| Status | Doc | What it covers |
+|---|---|---|
+| ✅ Shipped | [UI Redesign Spec](./superpowers/specs/2026-05-11-ui-redesign-material-design.md) | MD3 alignment — type scale, color roles, hero, cards, mobile nav |
+| ✅ Shipped | [UI Redesign Plan](./superpowers/plans/2026-05-11-ui-redesign-material-design.md) | 12-task implementation plan for the UI redesign |
+| 📋 Planned | [Power Station Categories Design](./superpowers/specs/2025-05-06-power-station-categories-design.md) | 7 new sub-category pages + comparisons + finder quiz |
+| 📋 Planned | [Power Station Category Expansion](./superpowers/plans/2025-05-06-power-station-category-expansion.md) | Implementation plan for the category expansion |
 
 ---
 

--- a/docs/for-designers.md
+++ b/docs/for-designers.md
@@ -21,7 +21,16 @@ Defined in `styles/theme.css` as HSL CSS variables. Use them through Tailwind ut
 | `--neutral-50 → 900` | warm grays | Body text, borders, surfaces |
 | `--success` / `--error` | semantic | Pros/cons, validation states |
 
-**Rule of thumb:** the accent orange is the loudest color in the system. Limit it to one element per viewport (typically an award badge or a CTA). Everything else lives in primary blue + neutral grays.
+**Updated color role usage:**
+
+| Token | Where it's used |
+|---|---|
+| `--primary` (#007ACC) | Header bg, score badges 8.0–8.9, active nav indicators, links |
+| `--accent` (#E87B35) | Score badges ≥9.0, all primary CTA buttons, award badges, Editor's Pick dot, TrustBar checkmarks |
+| `--primary-lightest` | Card hover surface tint, selected chip bg, trending widget bg |
+| `--success` | "In Stock" states only — not score badges |
+
+**Score badge color rule:** ≥9.0 = accent orange, 8.x = primary blue, 7.x = amber, <7 = neutral gray. Green is no longer used for scores.
 
 ## Typography
 
@@ -29,8 +38,22 @@ Two families, both Google Fonts with `display: swap`.
 
 | Family | Role | Typical sizes |
 |---|---|---|
-| **Playfair Display** (`--font-display`) | Editorial headings (article titles, hero headlines, section H2s) | 28–56px |
-| **Inter** (`--font-sans`) | Body, UI, metadata, captions | 13–17px |
+| **Playfair Display** (`--font-display`) | Editorial headings (article titles, hero headlines, section H2s) | 20px, 32px |
+| **Inter** (`--font-sans`) | Body, UI, metadata, captions | 11px, 14px, 15px |
+
+### Type scale — 5 roles (use these, nothing else)
+
+The site enforces a 5-role type system via Tailwind component utilities defined in `styles/global.css`. **Do not introduce new arbitrary `text-[Npx]` sizes.** Map every text element to one of these roles:
+
+| Class | Font | Size / Weight | Use |
+|---|---|---|---|
+| `.type-display` | Playfair Display | 32px / 800 | Hero `<h1>`, article titles |
+| `.type-headline` | Playfair Display | 20px / 700 | Section headings, card H2s |
+| `.type-title` | Inter | 15px / 600 | Product names in cards, CTA text |
+| `.type-body` | Inter | 14px / 400 | Descriptions, summaries, prose |
+| `.type-label` | Inter | 11px / 600 + uppercase + 0.06em tracking | Badges, metadata, dates, category chips |
+
+In practice: `<h1 className="type-display text-neutral-900">`, `<span className="type-label text-primary">`, etc. Color is always added separately — the role classes only set font, size, weight, and line-height.
 
 **Article-body type** (`.article-body` in `styles/global.css`):
 
@@ -106,6 +129,19 @@ Single input + button. Inline validation only; never a modal.
 ### `AdBanner`
 
 In dev, shows a **labeled gray placeholder** at the configured size. In prod, the real AdSense unit. Design around the *placeholder* dimensions so layouts don't shift when ads load (CLS budget is tight — target < 0.1).
+
+## State layers (MD3 interaction model)
+
+All interactive card surfaces use `.state-layer` (or `.state-layer-light` for amber/colored surfaces). These classes are defined in `styles/global.css` and replace ad-hoc hover background-color changes:
+
+- **Hover:** `opacity-[0.06]` primary-colored overlay + `translate-y(-0.5px)` lift + `shadow-card-hover`
+- **Active/pressed:** `opacity-[0.10]` overlay, no lift
+
+Apply `.state-layer` to any new card or interactive surface. Note that `overflow-hidden` is baked in — child `box-shadow` and overflow dropdowns will be clipped.
+
+## Mobile navigation
+
+On `< md` breakpoints, the `MobileBottomNav` component renders a fixed bottom bar with 4 tabs: Home, Best Of, Search (disabled placeholder), Categories. Categories opens a slide-up sheet. Design new mobile entry points as additional tabs here, not as hamburger expansions.
 
 ## Motion
 

--- a/docs/for-developers.md
+++ b/docs/for-developers.md
@@ -39,19 +39,22 @@ No database. No runtime API. The build is the database.
 
 ```
 app/                    Next.js App Router routes
-├── layout.tsx          Root layout (fonts, header/footer, GA, AdSense bootstrap)
-├── page.tsx            Home
+├── layout.tsx          Root layout — Header, TrustBar, main, Footer, MobileBottomNav
+├── page.tsx            Home — hero, 2/3-col ReviewCard grid, Best Of guide cards, sidebar
 ├── articles/[slug]/    Individual reviews (SSG, generateStaticParams)
 ├── best/               Category hub + verticals + sub-categories + compare pages
 ├── sitemap.ts          Auto-generated sitemap
 └── robots.ts           Auto-generated robots.txt
 
-components/             ~30 components (see reference/components.md for the catalog)
+components/             ~32 components (see reference/components.md for the catalog)
+├── TrustBar.tsx        RSC — trust signals strip shown below header on all pages
+├── MobileBottomNav.tsx 'use client' — persistent bottom nav bar + slide-up category sheet
 ├── article/            Article-specific (specs, pros/cons, score card, etc.)
 └── ads/                AdBanner, ResponsiveAd
 
 lib/                    Pure helpers, no React
 ├── Posts.ts            getPostBySlug, getAllPostSlugs, getPostsByCategory
+├── nav-categories.ts   Shared NAV_CATEGORIES array + NavCategory interface (used by Header + MobileBottomNav)
 ├── power-station-data.ts  Typed filters for the power-stations vertical
 ├── markdown.ts         marked + Tailwind class injection
 ├── articleUtils.ts     calculateOverallScore, scoreToStarRating, formatArticleDate
@@ -135,9 +138,22 @@ If you find yourself wanting MDX, push back — `marked` keeps content authorabl
 
 ## Styling
 
-- **Tailwind CSS 3.4**, configured in `tailwind.config.ts`. Content paths cover `app/` and `components/`.
+- **Tailwind CSS 3.4**, configured in `tailwind.config.ts`. Content paths cover `app/` and `components/`. `fontFamily.display` is registered, enabling the `font-display` utility for Playfair Display.
 - **Design tokens** live as CSS variables in `styles/theme.css` (consumed via Tailwind's `theme.extend`). Don't hardcode colors — reach for `--primary`, `--accent`, `--neutral-*`.
-- **Two fonts**: `--font-sans: Inter` (body), `--font-display: Playfair Display` (headings).
+- **Two fonts**: `--font-sans: Inter` (body), `--font-display: Playfair Display` (headings). Set exclusively via `next/font` in `app/layout.tsx` — do not re-declare `--font-display` in CSS (causes circular variable bug).
+- **Type scale** — 5 roles defined as Tailwind component utilities in `styles/global.css`:
+
+  | Class | Size / Weight | Use |
+  |---|---|---|
+  | `.type-display` | Playfair 32px / 800 | Hero headline, article `<h1>` |
+  | `.type-headline` | Playfair 20px / 700 | Section headings |
+  | `.type-title` | Inter 15px / 600 | Product names, card titles |
+  | `.type-body` | Inter 14px / 400 | Descriptions, summaries, prose |
+  | `.type-label` | Inter 11px / 600 uppercase | Badges, metadata, dates |
+
+  Do not introduce new arbitrary `text-[Npx]` sizes — map to one of these 5 roles.
+
+- **State layers** — `.state-layer` and `.state-layer-light` in `styles/global.css` implement MD3 hover/active interaction. Apply to any interactive card surface. Note: `overflow-hidden` is included — child `box-shadow` and overflow dropdowns will be clipped (see comment in `global.css`).
 - **Article body** has bespoke prose styling in `.article-body` (see `styles/global.css`). Use it on any rendered-markdown container.
 
 Designers' deeper take: [for-designers.md](./for-designers.md).
@@ -172,6 +188,23 @@ Full deploy notes: [`PRODUCTION.md`](../PRODUCTION.md).
 - Slots are typed via `ADSENSE_CONFIG` in `lib/adsense-config.ts`. Add a new slot there before referencing it.
 - `shouldShowAds()` gates rendering: dev shows a labeled placeholder; prod shows real ads only when `NEXT_PUBLIC_ADSENSE_PUBLISHER_ID` is set to a real `ca-pub-...` value.
 - The build emits a **warning** (not an error) if the env var is missing — see commit `89e8987`. Don't tighten this back to an error or CI will fail on forks.
+
+## Price visibility rule
+
+Prices are **not rendered on cards**. They appear only on individual article/review pages. This is intentional — cards will eventually carry "Check Price →" affiliate links instead. When building new card components, do not surface `price` from frontmatter.
+
+`buyUrl` is retained as an optional prop on `RankedProductCard` (prefixed `_buyUrl` in destructuring to satisfy ESLint) for future wiring — do not remove it.
+
+## Mobile navigation
+
+The site has two navigation layers:
+
+- **Desktop (md+):** Sticky `<Header>` with logo, `NAV_LINKS`, `<CategoryDropdown>`, `<SearchBar>`.
+- **Mobile (< md):** `<MobileBottomNav>` — a fixed bottom bar (Home · Best Of · Search · Categories) + a slide-up category sheet. The hamburger menu is gone.
+
+Both share the `NAV_CATEGORIES` array from `lib/nav-categories.ts`. Add new top-level categories there; they appear in both the desktop dropdown and the mobile sheet automatically.
+
+`<main>` in `layout.tsx` has `pb-16 md:pb-0` to prevent content from hiding behind the bottom bar on mobile.
 
 ## Local-dev gotchas
 

--- a/docs/reference/components.md
+++ b/docs/reference/components.md
@@ -6,11 +6,13 @@ A quick index of every component in `components/` with its purpose and the props
 
 | Component | File | Purpose |
 |---|---|---|
-| `Header` | `components/Header.tsx` | Top nav, logo, category dropdown, sticky on scroll |
+| `Header` | `components/Header.tsx` | Sticky desktop nav — logo, `NAV_LINKS`, `CategoryDropdown`, `SearchBar`. No mobile nav (see `MobileBottomNav`). |
+| `TrustBar` | `components/TrustBar.tsx` | RSC trust-signals strip below header on all pages. Dynamic post count + latest review date. |
+| `MobileBottomNav` | `components/MobileBottomNav.tsx` | `'use client'` — persistent bottom bar (mobile only) + slide-up category sheet. |
 | `Footer` | `components/Footer.tsx` | Footer links, social, copyright |
 | `Breadcrumb` | `components/Breadcrumb.tsx` | Breadcrumb trail (`Home › Best › Power Stations › RV`) |
-| `CategoryDropdown` | `components/CategoryDropdown.tsx` | Mobile-friendly category nav |
-| `SearchBar` | `components/SearchBar.tsx` | Client-side search/filter (`'use client'`) |
+| `CategoryDropdown` | `components/CategoryDropdown.tsx` | Desktop "More ▾" dropdown, uses `NAV_CATEGORIES` |
+| `SearchBar` | `components/SearchBar.tsx` | Client-side search/filter (`'use client'`), desktop-only |
 
 ## Product surfaces
 
@@ -26,18 +28,17 @@ A quick index of every component in `components/` with its purpose and the props
   image="https://..."
   summary="One-paragraph hook."
   score={9.2}
-  price="$999"
   badge="best-overall"           // 'best-overall' | 'best-value' | 'budget-pick'
-  buyUrl="https://amazon.com/..."
+  buyUrl="https://amazon.com/..."  // retained, not rendered yet — for future "Check Price"
   specs={{ Capacity: "1024 Wh" }}
 />
 ```
 
-Stretched-link card (whole card is clickable). Lift + shadow on hover. CTA morphs on hover.
+**No `price` prop** — prices are not shown on cards (only on full review pages). Stretched-link card (whole card clickable). Score badge at `size="lg"` with label. State layer + lift on hover. "Read Review →" ghost CTA.
 
 ### `ReviewCard`
 
-Compact home-page card. Same shape, smaller surface.
+Image-forward vertical card for the home page Latest Reviews grid (`grid-cols-2 sm:grid-cols-3`).
 
 ### `QuickPicks`
 
@@ -143,3 +144,5 @@ Adaptive wrapper that swaps between mobile/desktop slots based on viewport.
 | Insert an ad | `AdBanner` (never inline AdSense code) |
 | Insert any image | `OptimizedImage` |
 | Build a new card-shaped UI | Start from `card.tsx`, extend with `class-variance-authority` |
+| Add trust signals below the header | Already there via `TrustBar` in `layout.tsx` — update the `signals` array inside it |
+| Add a new top-level nav category | Add an entry to `lib/nav-categories.ts` — appears in desktop dropdown and mobile sheet automatically |

--- a/docs/superpowers/plans/2026-05-11-ui-redesign-material-design.md
+++ b/docs/superpowers/plans/2026-05-11-ui-redesign-material-design.md
@@ -1,0 +1,939 @@
+# UI Redesign — Material Design 3 Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign ProductLabR's UI to fix 5 high/medium impact engagement issues: under-powered hero, text-heavy cards, full-page mobile nav takeover, monochromatic palette, and inconsistent type scale — all aligned to Material Design 3 guidelines.
+
+**Architecture:** Approach B (design-system first): establish shared CSS utilities and a corrected color rule in ScoreBadge first, then apply to every component in dependency order. Two new components (TrustBar, MobileBottomNav) are wired into layout.tsx last so they render site-wide without touching individual pages. Prices are removed from all card surfaces; they remain only on full review pages.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript 5 strict, Tailwind CSS 3.4, Inter + Playfair Display (Google Fonts via next/font)
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|---|---|---|
+| Modify | `tailwind.config.ts` | Add `fontFamily.display` so `font-display` utility works |
+| Modify | `styles/global.css` | Add `.type-*` utilities + `.state-layer` / `.state-layer-light` |
+| Modify | `components/ScoreBadge.tsx` | Swap `bg-green-600` → `bg-accent`, `bg-blue-600` → `bg-primary` |
+| Create | `lib/nav-categories.ts` | Shared category list (used by Header + MobileBottomNav) |
+| Create | `components/TrustBar.tsx` | RSC trust-signals strip rendered under header on all pages |
+| Modify | `components/ReviewCard.tsx` | Image-forward vertical card, remove price, fix score scale |
+| Modify | `components/RankedProductCard.tsx` | Remove price + "In Stock", promote score badge, add state layer |
+| Modify | `app/page.tsx` | Hero redesign, ReviewCard grid, Best Of guide card icons |
+| Create | `components/MobileBottomNav.tsx` | Persistent bottom nav bar + slide-up category sheet |
+| Modify | `components/Header.tsx` | Remove mobile nav; import categories from shared lib |
+| Modify | `app/layout.tsx` | Add TrustBar + MobileBottomNav; add `pb-16 md:pb-0` to main |
+
+---
+
+## Task 1: Tailwind `font-display` + CSS type utilities + state layer
+
+**Files:**
+- Modify: `tailwind.config.ts`
+- Modify: `styles/global.css`
+
+- [ ] **Step 1: Add `fontFamily.display` to Tailwind config**
+
+Open `tailwind.config.ts` and add `display` to `theme.extend.fontFamily`:
+
+```ts
+// tailwind.config.ts — inside theme.extend.fontFamily
+fontFamily: {
+  sans: ['var(--font-sans)'],
+  display: ['var(--font-display)'],   // ← add this line
+},
+```
+
+- [ ] **Step 2: Add type utilities and state layer to global.css**
+
+Append to the bottom of `styles/global.css`:
+
+```css
+/* ── Type scale — 5 roles ───────────────────────────────────────────────── */
+@layer components {
+  .type-display  { @apply font-display text-[32px] font-extrabold leading-tight; }
+  .type-headline { @apply font-display text-[20px] font-bold leading-snug; }
+  .type-title    { @apply font-sans text-[15px] font-semibold leading-snug; }
+  .type-body     { @apply font-sans text-[14px] font-normal leading-relaxed; }
+  .type-label    { @apply font-sans text-[11px] font-semibold uppercase tracking-[0.06em]; }
+}
+
+/* ── MD3 state layers ───────────────────────────────────────────────────── */
+@layer components {
+  .state-layer {
+    @apply relative overflow-hidden;
+  }
+  .state-layer::after {
+    content: '';
+    @apply absolute inset-0 rounded-[inherit] opacity-0 transition-opacity duration-150 pointer-events-none;
+    background-color: hsl(var(--primary));
+  }
+  .state-layer:hover::after  { @apply opacity-[0.06]; }
+  .state-layer:active::after { @apply opacity-[0.10]; }
+
+  /* For cards with a coloured/dark surface (e.g. rank-1 amber-50 bg) */
+  .state-layer-light::after {
+    background-color: white;
+  }
+}
+```
+
+- [ ] **Step 3: Verify build picks up new utilities**
+
+```bash
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tailwind.config.ts styles/global.css
+git commit -m "feat(design): add type-scale utilities and MD3 state-layer classes"
+```
+
+---
+
+## Task 2: Update ScoreBadge color logic
+
+**Files:**
+- Modify: `components/ScoreBadge.tsx`
+
+- [ ] **Step 1: Update `getScoreBgClass`**
+
+Replace the existing `getScoreBgClass` function (lines ~16-22):
+
+```ts
+function getScoreBgClass(score: number): string {
+  if (score >= 9.0) return 'bg-accent';     // was bg-green-600
+  if (score >= 8.0) return 'bg-primary';    // was bg-blue-600
+  if (score >= 7.0) return 'bg-amber-500';
+  return 'bg-neutral-500';
+}
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Check visually**
+
+Open `http://localhost:3000` and navigate to any category page (e.g. `/best/power-stations/portable-power-stations`). Confirm top-ranked products with score ≥9.0 show **orange** badges and 8.x scores show **blue** badges.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/ScoreBadge.tsx
+git commit -m "feat(design): score badge ≥9.0 uses accent orange, 8.x uses primary blue"
+```
+
+---
+
+## Task 3: Extract shared nav categories + create TrustBar
+
+**Files:**
+- Create: `lib/nav-categories.ts`
+- Create: `components/TrustBar.tsx`
+
+- [ ] **Step 1: Create `lib/nav-categories.ts`**
+
+```ts
+// lib/nav-categories.ts
+export interface NavCategory {
+  name: string;
+  href: string;
+  icon: string;
+  count: number;
+}
+
+export const NAV_CATEGORIES: NavCategory[] = [
+  { name: 'Laptops',              href: '/best/laptops',          icon: '💻', count: 0  },
+  { name: 'TVs',                  href: '/best/tvs',              icon: '📺', count: 0  },
+  { name: 'Headphones & Earbuds', href: '/best/headphones',       icon: '🎧', count: 0  },
+  { name: 'Smartphones',          href: '/best/smartphones',      icon: '📱', count: 0  },
+  { name: 'Monitors',             href: '/best/monitors',         icon: '🖥️', count: 0  },
+  { name: 'Smart Home',           href: '/best/smart-home',       icon: '🏠', count: 0  },
+  { name: 'Wearables',            href: '/best/wearables',        icon: '⌚', count: 0  },
+  { name: 'Gaming',               href: '/best/gaming',           icon: '🎮', count: 0  },
+  { name: 'Cameras',              href: '/best/cameras',          icon: '📷', count: 15 },
+  { name: 'Power Stations',       href: '/best/power-stations',   icon: '⚡', count: 33 },
+];
+```
+
+- [ ] **Step 2: Create `components/TrustBar.tsx`**
+
+```tsx
+// components/TrustBar.tsx
+import getPostMetadata from '@/components/getPostMetadata';
+
+export function TrustBar() {
+  const count = getPostMetadata().length;
+  const signals = [
+    `${count} products tested`,
+    'Real-world conditions',
+    'No sponsored reviews',
+    `Updated ${new Date().toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}`,
+  ];
+
+  return (
+    <div className="bg-primary-dark px-4 py-1.5 sm:px-6">
+      <div className="mx-auto flex max-w-content items-center gap-4 overflow-x-auto">
+        {signals.map((signal) => (
+          <span key={signal} className="type-label flex flex-shrink-0 items-center gap-1.5 text-white/85">
+            <span className="text-success">✓</span>
+            {signal}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/nav-categories.ts components/TrustBar.tsx
+git commit -m "feat(design): add shared nav-categories and TrustBar RSC"
+```
+
+---
+
+## Task 4: Redesign ReviewCard → image-forward vertical card
+
+**Files:**
+- Modify: `components/ReviewCard.tsx`
+
+- [ ] **Step 1: Replace ReviewCard with vertical image-forward layout**
+
+Full file replacement:
+
+```tsx
+// components/ReviewCard.tsx
+import Link from 'next/link';
+import { OptimizedImage } from './OptimizedImage';
+import { ScoreBadge } from './ScoreBadge';
+import type { PostMetadata } from './PostMetadata';
+
+interface ReviewCardProps {
+  post: PostMetadata;
+}
+
+export function ReviewCard({ post }: ReviewCardProps) {
+  const score = post.ratingBreakdown
+    ? post.ratingBreakdown.metrics.reduce((sum, m) => sum + m.score, 0) /
+      post.ratingBreakdown.metrics.length
+    : post.rating
+      ? post.rating * 2
+      : null;
+
+  return (
+    <Link
+      href={`/articles/${post.slug}`}
+      className="state-layer group flex flex-col overflow-hidden rounded-xl border border-neutral-200 bg-white transition-all duration-200 hover:-translate-y-0.5 hover:shadow-card-hover"
+    >
+      <div className="relative aspect-[3/2] w-full overflow-hidden bg-gradient-to-br from-primary-lightest to-primary-light/30">
+        <OptimizedImage
+          src={post.image || post.productImage || '/images/item.png'}
+          alt={post.title}
+          fill
+          sizes="(max-width: 640px) 50vw, 33vw"
+          className="object-cover"
+        />
+        {score !== null && (
+          <div className="absolute right-2 top-2">
+            <ScoreBadge score={score} size="sm" />
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-1 flex-col p-3">
+        {post.category && (
+          <span className="type-label text-primary">{post.category}</span>
+        )}
+        <h3 className="type-title mt-1 line-clamp-2 text-neutral-900">{post.title}</h3>
+        {post.subtitle && (
+          <p className="type-body mt-1 line-clamp-2 text-neutral-500">{post.subtitle}</p>
+        )}
+        <span className="type-label mt-2 text-neutral-400">{post.date}</span>
+      </div>
+    </Link>
+  );
+}
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Preview visually**
+
+Open `http://localhost:3000`. The "Latest Reviews" section should now show image-forward grid cards instead of the horizontal list. Confirm score badges appear on images and no price is shown.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/ReviewCard.tsx
+git commit -m "feat(design): ReviewCard → image-forward vertical grid card, remove price"
+```
+
+---
+
+## Task 5: Update RankedProductCard — remove price, promote score badge, add state layer
+
+**Files:**
+- Modify: `components/RankedProductCard.tsx`
+
+- [ ] **Step 1: Replace RankedProductCard**
+
+Full file replacement:
+
+```tsx
+// components/RankedProductCard.tsx
+import Link from 'next/link';
+import { isSafeUrl } from '@/lib/utils';
+import { OptimizedImage } from './OptimizedImage';
+import { ScoreBadge } from './ScoreBadge';
+import { AwardBadge } from './AwardBadge';
+
+interface RankedProductCardProps {
+  rank: number;
+  name: string;
+  href: string;
+  image: string;
+  summary: string;
+  score: number;
+  badge?: 'best-overall' | 'best-value' | 'budget-pick';
+  buyUrl?: string;  // retained for future "Check Price" wiring — not rendered yet
+  specs?: Record<string, string>;
+}
+
+export function RankedProductCard({
+  rank, name, href, image, summary, score, badge, buyUrl, specs,
+}: RankedProductCardProps) {
+  const isTopRanked = rank === 1;
+
+  return (
+    <div
+      className={[
+        'group relative rounded-xl border border-neutral-200 p-5 cursor-pointer',
+        'transition-all duration-200 ease-out',
+        'hover:-translate-y-1 hover:shadow-xl hover:shadow-neutral-200/80',
+        isTopRanked
+          ? 'state-layer-light border-l-4 border-l-accent bg-amber-50/30'
+          : 'state-layer bg-white',
+      ].join(' ')}
+    >
+      {/* Stretched link — whole card clickable */}
+      <Link href={href} className="absolute inset-0 z-0 rounded-xl" aria-label={`Read ${name} review`} />
+
+      <div className="flex flex-col gap-5 sm:flex-row">
+        <div className="relative h-36 w-full flex-shrink-0 overflow-hidden rounded-lg bg-gradient-to-br from-primary-lightest to-primary-light/30 sm:w-44">
+          <OptimizedImage src={image} alt={name} fill sizes="180px" className="object-contain p-2" />
+        </div>
+
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            {badge && <AwardBadge type={badge} />}
+            <span className="type-label text-neutral-400">#{rank}</span>
+          </div>
+
+          <h3 className="type-title mt-1 text-neutral-900">{name}</h3>
+          <p className="type-body mt-1.5 text-neutral-500">{summary}</p>
+
+          <div className="mt-3 flex items-center gap-3">
+            <ScoreBadge score={score} size="lg" showLabel />
+            <span className="relative z-10 type-label text-primary hover:text-primary-dark">
+              Read Review →
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {specs && Object.keys(specs).length > 0 && (
+        <div className="mt-3.5 flex flex-wrap gap-4 border-t border-neutral-100 pt-3.5">
+          {Object.entries(specs).slice(0, 5).map(([key, value]) => (
+            <span key={key} className="type-label text-neutral-400">
+              {key}: <strong className="font-semibold text-neutral-700">{value}</strong>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Check all callers still compile**
+
+Any page that passes `price` or `buyLabel` to `RankedProductCard` will now get a TypeScript error (those props were removed). Search for usages:
+
+```bash
+grep -r "RankedProductCard" app/ --include="*.tsx" -l
+```
+
+Open each file returned and remove the `price={...}` and `buyLabel={...}` props from every `<RankedProductCard>` call.
+
+- [ ] **Step 3: Verify**
+
+```bash
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Preview visually**
+
+Open a category page e.g. `http://localhost:3000/best/power-stations/portable-power-stations`. Confirm: no prices shown, score badge is prominent (36×36), rank-1 card has amber tint + left accent border.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/RankedProductCard.tsx app/
+git commit -m "feat(design): RankedProductCard removes price, promotes score badge, adds state layer"
+```
+
+---
+
+## Task 6: Update Best Of Guide Cards on home page
+
+**Files:**
+- Modify: `app/page.tsx` (bestOfGuides section only)
+
+- [ ] **Step 1: Update `bestOfGuides` array in `app/page.tsx`**
+
+Replace the existing `bestOfGuides` const (near top of file):
+
+```ts
+const bestOfGuides = [
+  { title: 'Best Hybrid Cameras',          href: '/best/cameras/hybrid-cameras',                          count: 8,  icon: '📷', theme: 'blue',   updated: 'Mar 2026' },
+  { title: 'Best Portable Power Stations', href: '/best/power-stations/portable-power-stations',           count: 12, icon: '⚡', theme: 'orange', updated: 'Mar 2026' },
+  { title: 'Best Camping Power Stations',  href: '/best/power-stations/camping-power-stations',            count: 6,  icon: '🏕️', theme: 'green',  updated: 'Feb 2026' },
+  { title: 'Best Pro Photo Cameras',       href: '/best/cameras/professional-photo-cameras',               count: 5,  icon: '🎞️', theme: 'blue',   updated: 'Mar 2026' },
+];
+```
+
+- [ ] **Step 2: Replace the Best Of Guides JSX in `app/page.tsx`**
+
+Find the `{/* Best Of Guides */}` section and replace the entire `<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">` block:
+
+```tsx
+{/* Best Of Guides */}
+<SectionLabel>Best Of Guides</SectionLabel>
+<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+  {bestOfGuides.map((guide) => {
+    const tintClass =
+      guide.theme === 'orange' ? 'bg-amber-50'
+      : guide.theme === 'green' ? 'bg-green-50'
+      : 'bg-primary-lightest';
+    const badgeClass =
+      guide.theme === 'orange' ? 'bg-amber-50 text-accent'
+      : guide.theme === 'green' ? 'bg-green-50 text-success'
+      : 'bg-primary-lightest text-primary';
+
+    return (
+      <Link
+        key={guide.href}
+        href={guide.href}
+        className="state-layer relative overflow-hidden rounded-xl border border-neutral-200 bg-white p-4 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-card-hover"
+      >
+        {/* Tinted corner accent */}
+        <div
+          className={`pointer-events-none absolute right-0 top-0 h-14 w-14 rounded-bl-[60px] rounded-tr-xl ${tintClass} opacity-70`}
+        />
+        <span className="text-2xl">{guide.icon}</span>
+        <h3 className="type-title mt-2 text-neutral-900">{guide.title}</h3>
+        <div className="mt-2 flex items-center justify-between">
+          <span className="type-label text-neutral-400">Updated {guide.updated}</span>
+          <span className={`type-label rounded-full px-2 py-0.5 ${badgeClass}`}>
+            {guide.count} tested
+          </span>
+        </div>
+      </Link>
+    );
+  })}
+</div>
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Preview visually**
+
+Open `http://localhost:3000`. The "Best Of Guides" section should show cards with emoji icons, tinted corner accents (blue/orange/green), and "N tested" pill badges. No border-left stripes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/page.tsx
+git commit -m "feat(design): Best Of guide cards get emoji icon, tinted corner, tested-count badge"
+```
+
+---
+
+## Task 7: Redesign Hero section
+
+**Files:**
+- Modify: `app/page.tsx` (hero section only)
+
+- [ ] **Step 1: Replace the hero `<section>` in `app/page.tsx`**
+
+Find the `{/* Hero — Editor's Pick */}` section and replace the entire `<section>` block:
+
+```tsx
+{/* Hero — Editor's Pick */}
+<section className="-mx-4 bg-gradient-to-b from-primary-lightest via-blue-50 to-neutral-50 px-4 py-10 sm:-mx-6 sm:px-6">
+  <div className="flex items-center gap-2">
+    <span className="h-2 w-2 rounded-full bg-accent" />
+    <span className="type-label text-accent">Editor&apos;s Pick</span>
+  </div>
+
+  {featured && (
+    <div className="mt-5 grid items-center gap-6 md:grid-cols-2">
+      <div>
+        <h1 className="type-display text-neutral-900">{featured.title}</h1>
+        {featured.subtitle && (
+          <p className="type-body mt-3 max-w-md text-neutral-500">{featured.subtitle}</p>
+        )}
+
+        {featuredScore !== null && (
+          <div className="mt-4 flex items-center gap-3">
+            <ScoreBadge score={featuredScore} size="lg" showLabel />
+          </div>
+        )}
+
+        <div className="mt-5">
+          <Link
+            href={`/articles/${featured.slug}`}
+            className="inline-block rounded-md bg-accent px-6 py-3 type-title text-white transition-opacity hover:opacity-90"
+          >
+            Read Full Review →
+          </Link>
+        </div>
+      </div>
+
+      <div className="relative h-52 overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-featured md:h-64">
+        <OptimizedImage
+          src={featured.image || featured.productImage || '/images/item.png'}
+          alt={featured.title}
+          fill
+          sizes="(max-width: 768px) 100vw, 50vw"
+          className="object-contain p-4"
+        />
+      </div>
+    </div>
+  )}
+</section>
+```
+
+- [ ] **Step 2: Fix `featuredScore` calculation** (remove the erroneous `/10` division)
+
+Find the `featuredScore` const near the top of the `Home` function and replace it:
+
+```ts
+const featuredScore = featured?.ratingBreakdown
+  ? featured.ratingBreakdown.metrics.reduce((sum, m) => sum + m.score, 0) /
+    featured.ratingBreakdown.metrics.length
+  : featured?.rating
+    ? featured.rating * 2
+    : null;
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Preview visually**
+
+Open `http://localhost:3000`. The hero should now have:
+- Larger Playfair headline (32px)
+- Score badge in accent orange (if score ≥ 9.0)
+- Taller product image (h-64 on desktop)
+- Single "Read Full Review →" CTA in accent orange
+- No price shown
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/page.tsx
+git commit -m "feat(design): hero display headline, taller image, accent CTA, remove price + Buy Now"
+```
+
+---
+
+## Task 8: Update home page ReviewCard grid layout
+
+> Note: Tasks 6, 7, and 8 all edit `app/page.tsx`. Execute them in order — each step modifies a different section of the file.
+
+**Files:**
+- Modify: `app/page.tsx` (Latest Reviews section only)
+
+- [ ] **Step 1: Change `space-y-1` list to a 2/3-col grid**
+
+Find the `{/* Latest Reviews */}` section and replace the wrapper `<div>`:
+
+```tsx
+{/* Latest Reviews */}
+<SectionLabel>Latest Reviews</SectionLabel>
+<div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+  {recentPosts.map((post) => (
+    <ReviewCard key={post.slug} post={post} />
+  ))}
+</div>
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Preview visually**
+
+Open `http://localhost:3000`. Latest Reviews should be a 2-column grid on mobile, 3-column on sm+. Cards are image-forward with score badge overlaid.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/page.tsx
+git commit -m "feat(design): Latest Reviews changes from list to 2/3-col image-forward grid"
+```
+
+---
+
+## Task 9: Create MobileBottomNav component
+
+**Files:**
+- Create: `components/MobileBottomNav.tsx`
+
+- [ ] **Step 1: Create `components/MobileBottomNav.tsx`**
+
+```tsx
+// components/MobileBottomNav.tsx
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { NAV_CATEGORIES } from '@/lib/nav-categories';
+
+const NAV_ITEMS = [
+  { label: 'Home',       href: '/',      icon: '🏠' },
+  { label: 'Best Of',    href: '/best',  icon: '🏆' },
+  { label: 'Search',     href: null,     icon: '🔍' }, // triggers search — future hook
+] as const;
+
+export function MobileBottomNav() {
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const pathname = usePathname();
+
+  const isActive = (href: string | null) => href !== null && pathname === href;
+
+  return (
+    <>
+      {/* Slide-up category sheet */}
+      {sheetOpen && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-40 bg-black/30 md:hidden"
+            onClick={() => setSheetOpen(false)}
+            aria-hidden="true"
+          />
+
+          {/* Sheet */}
+          <div className="fixed inset-x-0 bottom-16 z-50 max-h-[60vh] overflow-y-auto rounded-t-2xl bg-white pb-4 shadow-xl md:hidden">
+            <div className="sticky top-0 bg-white px-4 pb-2 pt-3">
+              <div className="mx-auto h-1 w-8 rounded-full bg-neutral-300" />
+              <p className="type-label mt-2 text-neutral-500">All Categories</p>
+            </div>
+            <div className="grid grid-cols-2 gap-2 px-4">
+              {NAV_CATEGORIES.map((cat) => (
+                <Link
+                  key={cat.href}
+                  href={cat.href}
+                  onClick={() => setSheetOpen(false)}
+                  className="flex items-center gap-2 rounded-lg bg-neutral-50 px-3 py-3 transition-colors hover:bg-primary-lightest"
+                >
+                  <span className="text-lg">{cat.icon}</span>
+                  <span className="type-title text-neutral-800">{cat.name}</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Bottom nav bar */}
+      <nav className="fixed inset-x-0 bottom-0 z-50 grid grid-cols-4 border-t border-neutral-200 bg-white md:hidden">
+        {NAV_ITEMS.map((item) => {
+          const active = isActive(item.href);
+          return (
+            <Link
+              key={item.label}
+              href={item.href ?? '#'}
+              className="flex flex-col items-center gap-0.5 py-2"
+              aria-current={active ? 'page' : undefined}
+            >
+              <span className="text-xl leading-none">{item.icon}</span>
+              <span className={`type-label ${active ? 'text-primary' : 'text-neutral-400'}`}>
+                {item.label}
+              </span>
+              {active && <span className="h-0.5 w-4 rounded-full bg-primary" />}
+            </Link>
+          );
+        })}
+
+        {/* Categories — opens sheet, not a link */}
+        <button
+          type="button"
+          onClick={() => setSheetOpen((prev) => !prev)}
+          className="flex flex-col items-center gap-0.5 py-2"
+          aria-expanded={sheetOpen}
+          aria-label="Open categories"
+        >
+          <span className="text-xl leading-none">☰</span>
+          <span className={`type-label ${sheetOpen ? 'text-primary' : 'text-neutral-400'}`}>
+            Categories
+          </span>
+          {sheetOpen && <span className="h-0.5 w-4 rounded-full bg-primary" />}
+        </button>
+      </nav>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/MobileBottomNav.tsx
+git commit -m "feat(design): add MobileBottomNav with persistent bottom bar and slide-up sheet"
+```
+
+---
+
+## Task 10: Remove mobile nav from Header + import shared categories
+
+**Files:**
+- Modify: `components/Header.tsx`
+
+- [ ] **Step 1: Replace Header.tsx**
+
+Full file replacement:
+
+```tsx
+// components/Header.tsx
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { SearchBar } from './SearchBar';
+import { CategoryDropdown } from './CategoryDropdown';
+import { NAV_CATEGORIES } from '@/lib/nav-categories';
+
+interface SearchPost {
+  title: string;
+  slug: string;
+  category?: string;
+}
+
+interface HeaderProps {
+  posts?: SearchPost[];
+}
+
+const NAV_LINKS = [
+  { label: 'Laptops',     href: '/best/laptops'     },
+  { label: 'TVs',         href: '/best/tvs'          },
+  { label: 'Headphones',  href: '/best/headphones'   },
+];
+
+export function Header({ posts = [] }: HeaderProps) {
+  const pathname = usePathname();
+
+  return (
+    <header className="sticky top-0 z-50 bg-gradient-to-r from-primary to-primary-dark">
+      <div className="mx-auto flex max-w-content items-center justify-between px-4 py-3 sm:px-6">
+        <div className="flex items-center gap-6">
+          <Link href="/" className="text-base font-bold tracking-wide text-white">
+            PRODUCT LAB
+          </Link>
+          <nav className="hidden items-center gap-4 md:flex">
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`text-[13px] text-white/85 hover:text-white ${
+                  pathname.startsWith(link.href) ? 'border-b-2 border-white pb-0.5' : ''
+                }`}
+              >
+                {link.label}
+              </Link>
+            ))}
+            <CategoryDropdown categories={NAV_CATEGORIES} />
+          </nav>
+        </div>
+
+        <div className="hidden md:block">
+          <SearchBar posts={posts} variant="header" />
+        </div>
+      </div>
+    </header>
+  );
+}
+```
+
+- [ ] **Step 2: Verify `CategoryDropdown` still accepts `NAV_CATEGORIES`**
+
+`CategoryDropdown` expects `{ name, href, count }[]`. `NAV_CATEGORIES` has `{ name, href, icon, count }` — the extra `icon` field is fine (TypeScript structural typing allows extra props on objects passed to functions).
+
+```bash
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/Header.tsx
+git commit -m "feat(design): Header removes mobile nav takeover, uses shared nav-categories"
+```
+
+---
+
+## Task 11: Wire TrustBar + MobileBottomNav into layout.tsx
+
+**Files:**
+- Modify: `app/layout.tsx`
+
+- [ ] **Step 1: Update `app/layout.tsx`**
+
+Add the two new imports and update the `<body>` JSX. Replace the full `<body>` block:
+
+```tsx
+// Add to imports at top of app/layout.tsx:
+import { TrustBar } from '@/components/TrustBar';
+import { MobileBottomNav } from '@/components/MobileBottomNav';
+```
+
+Replace the `<body>` contents:
+
+```tsx
+<body className="font-sans antialiased bg-neutral-50 text-neutral-700">
+  <script
+    type="application/ld+json"
+    dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}
+  />
+  <Script
+    async
+    src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CONFIG.publisherId}`}
+    crossOrigin="anonymous"
+    strategy="afterInteractive"
+  />
+  <Header posts={posts} />
+  <TrustBar />
+  <main className="mx-auto max-w-[1280px] px-4 pb-16 sm:px-6 md:pb-0">
+    {children}
+  </main>
+  <Footer />
+  <MobileBottomNav />
+  {gaId && <GoogleAnalytics gaId={gaId} />}
+</body>
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+npm run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Preview the full site**
+
+Open `http://localhost:3000`:
+- Trust bar (dark blue strip with ✓ signals) should appear directly below the header on every page
+- Resize to mobile width (< 768px): bottom nav bar should be visible with Home / Best Of / Search / Categories tabs
+- Tap "Categories" on mobile: slide-up sheet should open with 2-column category grid
+- Page content should not be hidden behind the bottom bar (pb-16 padding)
+- Tap the backdrop or tap a category link: sheet should close
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/layout.tsx
+git commit -m "feat(design): wire TrustBar and MobileBottomNav into root layout"
+```
+
+---
+
+## Task 12: Final verification
+
+- [ ] **Step 1: Full build check**
+
+```bash
+npm run test:build
+```
+
+Expected: lint passes, type-check passes, build completes with all routes prerendered.
+
+- [ ] **Step 2: Acceptance criteria walkthrough**
+
+Check each item against the running dev server at `http://localhost:3000`:
+
+| Criterion | Where to check |
+|---|---|
+| 5 type roles as Tailwind utilities; no `text-[Npx]` in changed files | `grep -n 'text-\[' components/ReviewCard.tsx components/RankedProductCard.tsx app/page.tsx` — expect 0 hits |
+| Score ≥9.0 = accent orange, 8.x = primary blue | `/best/power-stations/portable-power-stations` |
+| No price on ReviewCard, RankedProductCard, hero, Best Of cards | Home page + any category page |
+| Bottom nav bar visible on mobile, hidden on desktop | Resize browser / DevTools mobile emulation |
+| Slide-up sheet opens/closes; backdrop closes it | Mobile view, tap Categories |
+| Trust bar below header on all pages | Home + article page + category page |
+| Hover = state layer + lift on cards | Hover any ReviewCard or RankedProductCard |
+| Best Of cards: emoji icon + "N tested" + tinted corner | Home page Best Of section |
+
+- [ ] **Step 3: Final commit if any last fixes applied**
+
+```bash
+git add -p
+git commit -m "fix(design): final polish from acceptance criteria walkthrough"
+```

--- a/docs/superpowers/specs/2026-05-11-ui-redesign-material-design.md
+++ b/docs/superpowers/specs/2026-05-11-ui-redesign-material-design.md
@@ -1,0 +1,240 @@
+# UI Redesign — Material Design 3 Alignment
+
+**Date:** 2026-05-11
+**Scope:** High + medium impact issues only (issues 1–5 from audit)
+**Goal:** Maximize user engagement and visual trust on ProductLabR
+
+---
+
+## 1. Context & Problem
+
+A consumer-perspective UI audit surfaced 8 issues against Google Material Design 3 guidelines. This spec covers the 5 high/medium impact issues:
+
+1. Hero section is under-powered (small image, weak headline, no trust signals)
+2. ReviewCards are text-heavy with tiny images (120×80px) and show price
+3. Mobile navigation is a full-page takeover that kills browsing context
+4. Monochromatic blue palette — accent orange underused, no surface differentiation
+5. 12 ad-hoc font sizes with no structured type scale
+
+**Cross-cutting change:** Prices removed from all cards (ReviewCard, RankedProductCard, category guide cards, hero). Prices remain only on individual article/review pages.
+
+---
+
+## 2. Design Foundation
+
+### 2.1 Type Scale — 5 roles (replaces 12 ad-hoc sizes)
+
+| Role | Font | Size | Weight | Usage |
+|---|---|---|---|---|
+| Display | Playfair Display | 32px | 800 | Hero headline, article `<h1>` |
+| Headline | Playfair Display | 20px | 700 | Section headings, card H2 |
+| Title | Inter | 15px | 600 | Product names in cards |
+| Body | Inter | 14px | 400 | Descriptions, summaries, prose |
+| Label | Inter | 11px | 600 + uppercase + 0.06em tracking | Badges, metadata, section labels, dates |
+
+**Retired sizes:** `text-[10px]`, `text-[13px]`, `text-[15px]`, `text-xl`, `text-2xl`, `text-3xl`, `text-4xl` as standalone arbitrary sizes — each must map to one of the 5 roles above.
+
+Implement as Tailwind `@layer base` utilities:
+```css
+.type-display  { @apply font-display text-[32px] font-extrabold leading-tight; }
+.type-headline { @apply font-display text-[20px] font-bold leading-snug; }
+.type-title    { @apply font-sans text-[15px] font-semibold leading-snug; }
+.type-body     { @apply font-sans text-[14px] font-normal leading-relaxed; }
+.type-label    { @apply font-sans text-[11px] font-semibold uppercase tracking-[0.06em]; }
+```
+
+### 2.2 Color Roles — updated usage rules
+
+Existing CSS variables are unchanged. Only usage rules are updated:
+
+| Token | New rule |
+|---|---|
+| `--primary` (#007ACC) | Header bg, primary buttons, score badges 8.0–8.9, active nav indicators |
+| `--accent` (#E87B35) | **Promoted:** all score badges ≥9.0, all primary CTA buttons, award badges, Editor's Pick dot, trust bar checkmarks |
+| `--primary-lightest` | Card hover surface tint, selected chip bg, trending widget bg |
+| `--success` | "In Stock" states only — no longer used for score badges |
+| Neutral-900 | All heading text — never use primary blue for large text blocks |
+
+**New rule for score badges:**
+- Score ≥ 9.0 → `bg-accent` (orange)
+- Score 8.0–8.9 → `bg-primary` (blue)
+- Score 7.0–7.9 → `bg-amber-500`
+- Score < 7.0 → `bg-neutral-500`
+
+### 2.3 State Layers — MD3 interaction model
+
+Replace ad-hoc hover background-color changes with consistent state layers:
+
+```css
+/* Applied to all interactive card surfaces */
+.state-layer {
+  @apply relative overflow-hidden;
+}
+.state-layer::after {
+  content: '';
+  @apply absolute inset-0 rounded-[inherit] opacity-0 transition-opacity duration-150 pointer-events-none;
+  /* white surface cards: primary tint; colored-surface cards override to bg-white */
+  background-color: hsl(var(--primary));
+}
+.state-layer:hover::after  { @apply opacity-[0.06]; }
+.state-layer:active::after { @apply opacity-[0.10]; }
+
+/* Variant for cards with a colored/dark surface (e.g. rank-1 amber-50 card) */
+.state-layer-light::after {
+  background-color: white;
+}
+```
+
+Cards additionally get `hover:-translate-y-0.5 hover:shadow-card-hover` for lift effect. The rank-1 `RankedProductCard` (amber-50 bg) uses `.state-layer-light`.
+
+---
+
+## 3. Component Changes
+
+### 3.1 Hero Section (`app/page.tsx`)
+
+**Changes:**
+- Trust bar: add a slim `<div>` between `<Header>` and the hero section with 4 credibility signals
+- Hero image: increase container from `h-44 md:h-52` → `h-52 md:h-64`; change `object-contain p-4` → `object-cover` with white-bg container
+- Headline: change from `text-2xl md:text-[26px]` → `type-display` (Playfair 32px/800)
+- Subtitle: `type-body` (14px/400)
+- Score badge: increase to `size="lg"` (36×36 block); use accent color for ≥9.0
+- Remove price display from hero
+- CTA: Keep "Read Full Review" as primary accent button; remove "Buy Now" button (price strategy change)
+
+**Trust bar markup** (new component `components/TrustBar.tsx`, RSC):
+```tsx
+import getPostMetadata from '@/components/getPostMetadata';
+// post count derived at build time — stays accurate as content grows
+const count = getPostMetadata().length;
+const signals = [
+  `${count} products tested`,
+  'Real-world conditions',
+  'No sponsored reviews',
+  `Updated ${new Date().toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}`,
+];
+// Rendered as slim strip below header: bg-primary-dark, 5px py, label-type text
+```
+
+### 3.2 ReviewCard (`components/ReviewCard.tsx`)
+
+**Layout change:** horizontal list → vertical image-forward card.
+
+```
+┌────────────────────┐
+│  [image — 3:2]     │  ← score badge overlaid top-right
+│  ← full width →    │
+├────────────────────┤
+│  LABEL (category)  │
+│  Title (15px/600)  │
+│  Body (14px/400)   │
+│  date · · · · · ·  │
+└────────────────────┘
+```
+
+- **Image:** `aspect-[3/2]` full width, `object-cover`, white bg
+- **Score badge:** `absolute top-2 right-2`, sized `px-2 py-0.5`, color by score rule above
+- **Remove:** `{post.price}` — not rendered
+- **Grid:** home page changes from `space-y-1` list → `grid grid-cols-2 gap-4 sm:grid-cols-3`
+- **Hover:** state layer + `hover:-translate-y-0.5 hover:shadow-card-hover`
+
+### 3.3 RankedProductCard (`components/RankedProductCard.tsx`)
+
+**Changes:**
+- Remove `{price}` and "In Stock" text entirely from render
+- Score badge: promote to `size="lg"` 36×36 block; apply new color rule
+- Score label ("Excellent") shown in accent color next to badge
+- `buyUrl` CTA: keep as ghost button `"Read Review →"` (label change); `buyLabel` prop deprecated
+- State layer added to card wrapper
+
+**Props change:** `price` removed from interface. `buyLabel` prop removed. `buyUrl` made optional and **not rendered** — retained on the interface so a future "Check Price" CTA can be wired in without a breaking change. The "Read Review →" link uses the existing `href` prop.
+
+### 3.4 Best Of Guide Cards (home page, `app/page.tsx`)
+
+Replace `bestOfGuides` array cards with new `CategoryGuideCard` pattern:
+
+Each card gets:
+- **Emoji icon** (configured per guide in the `bestOfGuides` array)
+- **Tinted corner accent** (top-right quarter-circle, color matches category theme)
+- **"N tested" pill badge** (accent/primary/success color by category)
+- Remove border-left colored stripe
+- Remove price-range text
+
+```tsx
+const bestOfGuides = [
+  { title: 'Best Hybrid Cameras',            href: '...', count: 8,  icon: '📷', theme: 'blue',   updated: 'Mar 2026' },
+  { title: 'Best Portable Power Stations',   href: '...', count: 12, icon: '⚡', theme: 'orange', updated: 'Mar 2026' },
+  { title: 'Best Camping Power Stations',    href: '...', count: 6,  icon: '🏕️', theme: 'green',  updated: 'Feb 2026' },
+  { title: 'Best Pro Photo Cameras',         href: '...', count: 5,  icon: '🎞️', theme: 'blue',   updated: 'Mar 2026' },
+];
+```
+
+Theme → tint mapping: `blue` = primary-lightest, `orange` = amber-50, `green` = green-50.
+
+### 3.5 Mobile Navigation (`components/Header.tsx`)
+
+**Replace** the existing hamburger full-page nav with a two-piece mobile pattern:
+
+**A. Persistent bottom nav bar** (new component `components/MobileBottomNav.tsx`, `'use client'`):
+- Fixed bottom, `z-50`, white bg, border-top
+- 4 destinations: Home · Best Of · Categories · Search
+- Active tab: primary color icon + label + 2px indicator line
+- "Categories" tap opens the slide-up sheet
+- Hidden on `md+` breakpoints
+
+**B. Slide-up category sheet** (within `MobileBottomNav`):
+- Triggered by "Categories" tap; state: `sheetOpen: boolean`
+- `fixed inset-x-0 bottom-0 z-50`, slides up via `transform translate-y`
+- Drag handle pill at top
+- `grid grid-cols-2 gap-2` of category tiles — each with emoji icon + name
+- Backdrop `div` at `z-40` closes sheet on tap
+- `max-h-[60vh] overflow-y-auto`
+
+**Remove** from `Header.tsx`:
+- `mobileOpen` state
+- hamburger `<button>` on mobile
+- Mobile nav `<div>` (the full-column dropdown)
+
+`Header.tsx` retains its sticky desktop nav; `MobileBottomNav` is added to `app/layout.tsx` alongside `<Header>`.
+
+**Body padding:** add `pb-16 md:pb-0` to `<main>` in `app/layout.tsx` to prevent content from hiding behind the bottom bar.
+
+---
+
+## 4. Files Changed
+
+| File | Change |
+|---|---|
+| `styles/global.css` | Add `.type-*` utility classes, `.state-layer` mixin |
+| `styles/theme.css` | No token changes — usage rule changes only |
+| `components/TrustBar.tsx` | New RSC — trust signals strip |
+| `components/MobileBottomNav.tsx` | New client component — bottom bar + slide-up sheet |
+| `components/ReviewCard.tsx` | Layout → image-forward grid card; remove price |
+| `components/RankedProductCard.tsx` | Remove price + "In Stock"; promote score badge; state layer |
+| `components/ScoreBadge.tsx` | Update `getScoreBgClass` — accent for ≥9.0 |
+| `app/page.tsx` | Hero redesign; trust bar; ReviewCard grid layout; Best Of card icons |
+| `app/layout.tsx` | Add `<TrustBar>`, `<MobileBottomNav>`; add `pb-16 md:pb-0` to main |
+
+---
+
+## 5. Out of Scope
+
+- Article page redesign (prices stay on review pages — no change needed)
+- Dark mode
+- Animation library changes (Framer Motion usage stays as-is)
+- AdSense slot positions
+- Any new routes or content changes
+
+---
+
+## 6. Acceptance Criteria
+
+- [ ] All 5 type roles defined as Tailwind utilities; no arbitrary `text-[Npx]` sizes remain in the changed files
+- [ ] Score badge is accent orange for ≥9.0, primary blue for 8.0–8.9 across ReviewCard, RankedProductCard, and hero
+- [ ] Price field not rendered on ReviewCard, RankedProductCard, hero, or Best Of guide cards
+- [ ] Bottom nav bar visible on mobile (`< md`), hidden on desktop
+- [ ] Slide-up category sheet opens/closes correctly; backdrop closes it
+- [ ] Trust bar renders below header on all pages
+- [ ] Hover states use state layer + lift on all cards (no background-color-only hover)
+- [ ] Best Of guide cards show emoji icon + "N tested" badge + tinted corner accent
+- [ ] `npm run test:build` passes (lint + type-check + build)

--- a/lib/nav-categories.ts
+++ b/lib/nav-categories.ts
@@ -1,0 +1,19 @@
+export interface NavCategory {
+  name: string;
+  href: string;
+  icon: string;
+  count: number;
+}
+
+export const NAV_CATEGORIES: NavCategory[] = [
+  { name: 'Laptops',              href: '/best/laptops',          icon: '💻', count: 0  },
+  { name: 'TVs',                  href: '/best/tvs',              icon: '📺', count: 0  },
+  { name: 'Headphones & Earbuds', href: '/best/headphones',       icon: '🎧', count: 0  },
+  { name: 'Smartphones',          href: '/best/smartphones',      icon: '📱', count: 0  },
+  { name: 'Monitors',             href: '/best/monitors',         icon: '🖥️', count: 0  },
+  { name: 'Smart Home',           href: '/best/smart-home',       icon: '🏠', count: 0  },
+  { name: 'Wearables',            href: '/best/wearables',        icon: '⌚', count: 0  },
+  { name: 'Gaming',               href: '/best/gaming',           icon: '🎮', count: 0  },
+  { name: 'Cameras',              href: '/best/cameras',          icon: '📷', count: 15 },
+  { name: 'Power Stations',       href: '/best/power-stations',   icon: '⚡', count: 33 },
+];

--- a/lib/nav-categories.ts
+++ b/lib/nav-categories.ts
@@ -2,18 +2,18 @@ export interface NavCategory {
   name: string;
   href: string;
   icon: string;
-  count: number;
+  count?: number;
 }
 
 export const NAV_CATEGORIES: NavCategory[] = [
-  { name: 'Laptops',              href: '/best/laptops',          icon: '💻', count: 0  },
-  { name: 'TVs',                  href: '/best/tvs',              icon: '📺', count: 0  },
-  { name: 'Headphones & Earbuds', href: '/best/headphones',       icon: '🎧', count: 0  },
-  { name: 'Smartphones',          href: '/best/smartphones',      icon: '📱', count: 0  },
-  { name: 'Monitors',             href: '/best/monitors',         icon: '🖥️', count: 0  },
-  { name: 'Smart Home',           href: '/best/smart-home',       icon: '🏠', count: 0  },
-  { name: 'Wearables',            href: '/best/wearables',        icon: '⌚', count: 0  },
-  { name: 'Gaming',               href: '/best/gaming',           icon: '🎮', count: 0  },
+  { name: 'Laptops',              href: '/best/laptops',          icon: '💻' },
+  { name: 'TVs',                  href: '/best/tvs',              icon: '📺' },
+  { name: 'Headphones & Earbuds', href: '/best/headphones',       icon: '🎧' },
+  { name: 'Smartphones',          href: '/best/smartphones',      icon: '📱' },
+  { name: 'Monitors',             href: '/best/monitors',         icon: '🖥️' },
+  { name: 'Smart Home',           href: '/best/smart-home',       icon: '🏠' },
+  { name: 'Wearables',            href: '/best/wearables',        icon: '⌚' },
+  { name: 'Gaming',               href: '/best/gaming',           icon: '🎮' },
   { name: 'Cameras',              href: '/best/cameras',          icon: '📷', count: 15 },
   { name: 'Power Stations',       href: '/best/power-stations',   icon: '⚡', count: 33 },
 ];

--- a/styles/global.css
+++ b/styles/global.css
@@ -141,10 +141,9 @@ h2 {
   .type-title    { @apply font-sans text-[15px] font-semibold leading-snug; }
   .type-body     { @apply font-sans text-[14px] font-normal leading-relaxed; }
   .type-label    { @apply font-sans text-[11px] font-semibold uppercase tracking-[0.06em]; }
-}
 
-/* ── MD3 state layers ───────────────────────────────────────────────────── */
-@layer components {
+  /* ── MD3 state layers ───────────────────────────────────────────────────── */
+  /* overflow-hidden clips ::after to card bounds; child box-shadows and overflow dropdowns will be clipped */
   .state-layer {
     @apply relative overflow-hidden;
   }

--- a/styles/global.css
+++ b/styles/global.css
@@ -133,3 +133,31 @@ h2 {
 .article-body hr {
   display: none;
 }
+
+/* ── Type scale — 5 roles ───────────────────────────────────────────────── */
+@layer components {
+  .type-display  { @apply font-display text-[32px] font-extrabold leading-tight; }
+  .type-headline { @apply font-display text-[20px] font-bold leading-snug; }
+  .type-title    { @apply font-sans text-[15px] font-semibold leading-snug; }
+  .type-body     { @apply font-sans text-[14px] font-normal leading-relaxed; }
+  .type-label    { @apply font-sans text-[11px] font-semibold uppercase tracking-[0.06em]; }
+}
+
+/* ── MD3 state layers ───────────────────────────────────────────────────── */
+@layer components {
+  .state-layer {
+    @apply relative overflow-hidden;
+  }
+  .state-layer::after {
+    content: '';
+    @apply absolute inset-0 rounded-[inherit] opacity-0 transition-opacity duration-150 pointer-events-none;
+    background-color: hsl(var(--primary));
+  }
+  .state-layer:hover::after  { @apply opacity-[0.06]; }
+  .state-layer:active::after { @apply opacity-[0.10]; }
+
+  /* For cards with a coloured/dark surface (e.g. rank-1 amber-50 bg) */
+  .state-layer-light::after {
+    background-color: white;
+  }
+}

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -43,5 +43,4 @@
 
   /* Font */
   --font-sans: var(--font-inter), ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-display: var(--font-display), 'Playfair Display', Georgia, serif;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,6 +10,7 @@ const config: Config = {
     extend: {
       fontFamily: {
         sans: ['var(--font-sans)'],
+        display: ['var(--font-display)'],
       },
       colors: {
         primary: {


### PR DESCRIPTION
## Summary

Redesigns the site's UI to fix 5 high/medium impact engagement issues identified in a consumer-perspective audit against Google Material Design 3 guidelines. Prices are removed from all card surfaces (they remain on full review pages only) in preparation for future affiliate "Check Price" links.

## Details

**Design foundation**
- `tailwind.config.ts`: adds `fontFamily.display` so `font-display` works as a Tailwind utility
- `styles/global.css`: adds 5-role type scale (`.type-display/headline/title/body/label`) and MD3 state layers (`.state-layer`, `.state-layer-light`) as `@layer components` utilities
- `styles/theme.css`: removes circular `--font-display` self-reference that was breaking Next.js font optimisation
- `components/ScoreBadge.tsx`: score ≥9.0 now uses `bg-accent` (orange), 8.x uses `bg-primary` (blue); green removed from score badges

**New components**
- `lib/nav-categories.ts`: single source of truth for `NAV_CATEGORIES` (name, href, icon, optional count) shared by Header and MobileBottomNav
- `components/TrustBar.tsx`: RSC trust-signals strip (dynamic post count derived from `getPostMetadata()`, latest review date, no-sponsored-reviews signal) rendered site-wide via layout
- `components/MobileBottomNav.tsx`: persistent bottom nav bar (`md:hidden`) with 4 tabs — Home, Best Of, disabled Search placeholder, Categories — plus a slide-up category sheet with `role="dialog"` and `aria-modal`

**Card redesigns**
- `components/ReviewCard.tsx`: horizontal list → vertical image-forward card (`aspect-[3/2]`, score badge overlaid top-right, `state-layer`, `grid-cols-2 sm:grid-cols-3` on home); price removed; NaN guard added for empty metrics arrays
- `components/RankedProductCard.tsx`: price and "In Stock" removed; score badge promoted to `size="lg" showLabel`; buy button replaced with "Read Review →" ghost link; `state-layer`/`state-layer-light` applied; `buyUrl` retained as optional unused prop for future wiring

**Home page (`app/page.tsx`)**
- Hero: `type-display` Playfair headline, taller image (`h-52 md:h-64`), single accent CTA, price and Buy Now button removed, `featuredScore` bug fixed (was erroneously dividing by 10)
- Latest Reviews: `space-y-1` list → `grid grid-cols-2 sm:grid-cols-3`
- Best Of Guides: border-left cards → emoji icon + tinted corner accent + "N tested" pill badge

**Navigation (`components/Header.tsx`, `app/layout.tsx`)**
- Header: mobile hamburger nav removed; imports `NAV_CATEGORIES` from shared lib
- Layout: `<TrustBar />` added after Header; `<MobileBottomNav />` added before `</body>`; `pb-16 md:pb-0` on `<main>` prevents content hiding behind bottom bar

**Docs (`docs/`)**
- Spec: `docs/superpowers/specs/2026-05-11-ui-redesign-material-design.md`
- Plan: `docs/superpowers/plans/2026-05-11-ui-redesign-material-design.md`
- Updated: `docs/for-developers.md`, `docs/for-designers.md`, `docs/reference/components.md`, `docs/README.md`

## Testing Done

- [ ] `npm run test:build` passes (lint + type-check + 150 static pages generated)
- [ ] Home page: hero shows Playfair headline, no price, single accent CTA
- [ ] Home page: Latest Reviews renders as 2-col (mobile) / 3-col (sm+) image grid
- [ ] Home page: Best Of cards show emoji icon, tinted corner, "N tested" badge
- [ ] Category page (e.g. `/best/power-stations/portable-power-stations`): no prices on ranked cards; score ≥9.0 shows orange badge
- [ ] Mobile (< 768px): bottom nav bar visible; Categories opens slide-up sheet; page content not hidden behind bar
- [ ] Desktop (≥ 768px): bottom nav hidden; Header shows desktop nav + search
- [ ] Trust bar visible below header on home, article, and category pages
- [ ] Article pages: prices still shown (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)